### PR TITLE
Repairing lastModified backup issue.

### DIFF
--- a/src/backup/after_backup_action_handler.py
+++ b/src/backup/after_backup_action_handler.py
@@ -85,8 +85,7 @@ class AfterBackupActionHandler(JsonHandler):
 
         backup = Backup(
             parent=table_entity.key,
-            last_modified=
-            source_table_metadata.get_last_modified_datetime(),
+            last_modified=copy_job_results.start_time,
             created=copy_job_results.end_time,
             dataset_id=copy_job_results.target_dataset_id,
             table_id=copy_job_results.target_table_id,

--- a/src/backup/datastore/Backup.py
+++ b/src/backup/datastore/Backup.py
@@ -8,7 +8,7 @@ from commons.decorators.retry import retry
 
 class Backup(ndb.Model):
 
-    # date of last modification which could be included in Backup
+    # date of last modification that will be included in the Backup
     # (copyJob start time - as it is atomic operation
     # and every change before that point is included in copy)
     last_modified = ndb.DateTimeProperty(indexed=True)

--- a/src/backup/datastore/Backup.py
+++ b/src/backup/datastore/Backup.py
@@ -7,12 +7,21 @@ from commons.decorators.retry import retry
 
 
 class Backup(ndb.Model):
-    # source table last modified
+
+    # date of last modification which could be included in Backup
+    # (copyJob start time - as it is atomic operation
+    # and every change before that point is included in copy)
     last_modified = ndb.DateTimeProperty(indexed=True)
+
+    # date of backup table creation (copyJob end)
     created = ndb.DateTimeProperty(auto_now_add=True, indexed=True)
+
     table_id = ndb.StringProperty(indexed=True)
+
     dataset_id = ndb.StringProperty(indexed=True)
+
     numBytes = ndb.IntegerProperty(indexed=True)
+
     deleted = ndb.DateTimeProperty(indexed=True)
 
     @classmethod

--- a/tests/backup/test_after_backup_action_handler.py
+++ b/tests/backup/test_after_backup_action_handler.py
@@ -2,6 +2,8 @@ import jsonpickle
 import os
 from datetime import datetime
 
+from jsonpickle import json
+from src.backup.copy_job_async.copy_job_result import CopyJobResult
 from src.big_query.big_query_table_metadata import BigQueryTableMetadata
 from tests import test_utils
 
@@ -65,6 +67,7 @@ class TestAfterBackupActionHandler(unittest.TestCase):
             "data": data,
             "jobJson": JobResultExample.DONE}
         )
+        copy_job_result = CopyJobResult(json.loads(payload).get('jobJson'))
 
         # when
         response = self.under_test.post(
@@ -77,6 +80,10 @@ class TestAfterBackupActionHandler(unittest.TestCase):
         self.assertEqual(backup.dataset_id, "target_dataset_id")
         self.assertEqual(backup.table_id, "target_table_id")
         self.assertTrue(isinstance(backup.created, datetime))
+        self.assertEqual(backup.created, copy_job_result.end_time)
+
+        self.assertTrue(isinstance(backup.last_modified, datetime))
+        self.assertEqual(backup.last_modified, copy_job_result.start_time)
 
     @patch('src.backup.after_backup_action_handler.ErrorReporting')
     @patch.object(BigQuery, '_create_http')


### PR DESCRIPTION
Now, as lastModified field value for Backup entity, copyJob startTime is used.
Copy job is atomic operation, so it allows to think that every change before that time is copied.
lastModified time meaning is now: 'time of last modifiaction which could be included in this copy'.
Note that copyJob doesn't copy data which are still in streaming buffer. Nevertheless, flushing streaming buffer changes lastModified time of the table, so backup will be done next day.

Using copyJobStart time instead of checking lastModified field of the source table AFTER doing copy job, resolves data incosistency probles data when between copyJob and after_backup_action there was a new change in source table.
Mentioned problem causes situations that some data was never backed up.