### PR TITLE
Repairing numBytes issue. numBytes is now showing exact numBytes from…

### DIFF
--- a/src/backup/after_backup_action_handler.py
+++ b/src/backup/after_backup_action_handler.py
@@ -62,7 +62,8 @@ class AfterBackupActionHandler(JsonHandler):
                 self.__disable_partition_expiration(
                     copy_job_results.target_table_reference)
         else:
-            logging.info(
+            pass
+            ErrorReporting().report(
                 "Backup table {0} not exist. Backup entity is not created".format(
                     copy_job_results.target_table_reference))
 

--- a/src/backup/after_backup_action_handler.py
+++ b/src/backup/after_backup_action_handler.py
@@ -52,34 +52,35 @@ class AfterBackupActionHandler(JsonHandler):
             ErrorReporting().report(error_message)
             return
 
-        source_table_reference = self.__create_table_reference(
-            data["sourceBqTable"])
-        source_table_metadata = BigQueryTableMetadata.get_table_by_reference(
-            source_table_reference)
+        backup_table_metadata = BigQueryTableMetadata.get_table_by_reference(
+            copy_job_results.target_table_reference)
 
-        if source_table_metadata.table_exists():
-            self.__create_backup(source_table_reference, source_table_metadata,
+        if backup_table_metadata.table_exists():
+            self.__create_backup(backup_table_metadata,
                                  copy_job_results)
-            if source_table_metadata.has_partition_expiration():
-                self.__disable_partition_expiration(copy_job_results)
+            if backup_table_metadata.has_partition_expiration():
+                self.__disable_partition_expiration(
+                    copy_job_results.target_table_reference)
         else:
             logging.info(
-                "Source table {0} not exist. Backup entity is not created".format(
-                    source_table_reference))
+                "Backup table {0} not exist. Backup entity is not created".format(
+                    copy_job_results.target_table_reference))
 
-    def __disable_partition_expiration(self, copy_job_results):
+    def __disable_partition_expiration(self, backup_table_reference):
         self.BQ.disable_partition_expiration(
-            copy_job_results.target_project_id,
-            copy_job_results.target_dataset_id,
-            copy_job_results.target_table_id
+            backup_table_reference.project_id,
+            backup_table_reference.dataset_id,
+            backup_table_reference.table_id
         )
 
     @staticmethod
     @retry(DatastoreTableGetRetriableException, tries=6, delay=4, backoff=2)
-    def __create_backup(source_table_reference, source_table_metadata,
-                        copy_job_results):
+    def __create_backup(backup_table_metadata, copy_job_results):
 
-        table_entity = Table.get_table_by_reference(source_table_reference)
+        table_entity = Table.get_table_by_reference(
+            copy_job_results.source_table_reference
+        )
+
         if table_entity is None:
             raise DatastoreTableGetRetriableException()
 
@@ -89,11 +90,13 @@ class AfterBackupActionHandler(JsonHandler):
             created=copy_job_results.end_time,
             dataset_id=copy_job_results.target_dataset_id,
             table_id=copy_job_results.target_table_id,
-            numBytes=source_table_metadata.table_size_in_bytes()
+            numBytes=backup_table_metadata.table_size_in_bytes()
         )
         logging.debug(
             "Saving backup to datastore, source:{0}, target:{1}".format(
-                source_table_reference, copy_job_results.target_bq_table))
+                copy_job_results.source_bq_table,
+                copy_job_results.target_bq_table))
+
         backup.insert_if_absent(backup)
 
     @staticmethod

--- a/src/backup/copy_job_async/copy_job_result.py
+++ b/src/backup/copy_job_async/copy_job_result.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from src.big_query.big_query_table import BigQueryTable
+from src.table_reference import TableReference
 
 
 class CopyJobResult(object):
@@ -36,6 +37,16 @@ class CopyJobResult(object):
                              self.source_table_id)
 
     @property
+    def source_table_reference(self):
+        table_id, partition_id = BigQueryTable \
+            .split_table_and_partition_id(self.source_table_id)
+
+        return TableReference(project_id=self.source_project_id,
+                              dataset_id=self.source_dataset_id,
+                              table_id=table_id,
+                              partition_id=partition_id)
+
+    @property
     def start_time(self):
         start_time = float(self.__job_json['statistics']['startTime']) / 1000.0
         return datetime.fromtimestamp(start_time)
@@ -61,6 +72,16 @@ class CopyJobResult(object):
     def target_bq_table(self):
         return BigQueryTable(self.target_project_id, self.target_dataset_id,
                              self.target_table_id)
+
+    @property
+    def target_table_reference(self):
+        table_id, partition_id = BigQueryTable\
+            .split_table_and_partition_id(self.target_table_id)
+
+        return TableReference(project_id=self.target_project_id,
+                              dataset_id=self.target_dataset_id,
+                              table_id=table_id,
+                              partition_id=partition_id)
 
     def has_errors(self):
         return 'errors' in self.__job_json['status']

--- a/src/backup/copy_job_async/copy_job_result.py
+++ b/src/backup/copy_job_async/copy_job_result.py
@@ -38,13 +38,7 @@ class CopyJobResult(object):
 
     @property
     def source_table_reference(self):
-        table_id, partition_id = BigQueryTable \
-            .split_table_and_partition_id(self.source_table_id)
-
-        return TableReference(project_id=self.source_project_id,
-                              dataset_id=self.source_dataset_id,
-                              table_id=table_id,
-                              partition_id=partition_id)
+        return TableReference.from_bq_table(self.source_bq_table)
 
     @property
     def start_time(self):
@@ -75,13 +69,8 @@ class CopyJobResult(object):
 
     @property
     def target_table_reference(self):
-        table_id, partition_id = BigQueryTable\
-            .split_table_and_partition_id(self.target_table_id)
+        return TableReference.from_bq_table(self.target_bq_table)
 
-        return TableReference(project_id=self.target_project_id,
-                              dataset_id=self.target_dataset_id,
-                              table_id=table_id,
-                              partition_id=partition_id)
 
     def has_errors(self):
         return 'errors' in self.__job_json['status']

--- a/src/table_reference.py
+++ b/src/table_reference.py
@@ -13,6 +13,13 @@ class TableReference(object):
     def from_table_entity(table):
         return TableReference(table.project_id, table.dataset_id,
                               table.table_id, table.partition_id)
+    @staticmethod
+    def from_bq_table(bq_table):
+        table_id, partition_id = BigQueryTable.split_table_and_partition_id(bq_table.table_id)
+        return TableReference(project_id=bq_table.project_id,
+                              dataset_id=bq_table.dataset_id,
+                              table_id=table_id,
+                              partition_id=partition_id)
 
     @staticmethod
     def parse_tab_ref(string):

--- a/tests/backup/copy_job_async/test_copy_job_result.py
+++ b/tests/backup/copy_job_async/test_copy_job_result.py
@@ -1,0 +1,32 @@
+import unittest
+
+from src.backup.copy_job_async.copy_job_result import CopyJobResult
+from src.table_reference import TableReference
+from tests.backup.copy_job_async.result_check.job_result_example import \
+    JobResultExample
+
+
+class TestCopyJobResult(unittest.TestCase):
+
+    def test_source_table_reference(self):
+        # given
+        copy_job_result = CopyJobResult(JobResultExample.DONE)
+        # when
+        source_table_reference = copy_job_result.source_table_reference
+        # then
+        self.assertEqual(source_table_reference,
+                         TableReference(project_id="source_project_id",
+                                        dataset_id="source_dataset_id",
+                                        table_id="source_table_id",
+                                        partition_id="123"))
+
+    def test_target_table_reference(self):
+        # given
+        copy_job_result = CopyJobResult(JobResultExample.DONE)
+        # when
+        target_table_reference = copy_job_result.target_table_reference
+        # then
+        self.assertEqual(target_table_reference,
+                         TableReference(project_id="target_project_id",
+                                        dataset_id="target_dataset_id",
+                                        table_id="target_table_id"))

--- a/tests/backup/test_after_backup_action_handler.py
+++ b/tests/backup/test_after_backup_action_handler.py
@@ -50,9 +50,10 @@ class TestAfterBackupActionHandler(unittest.TestCase):
         ])
 
         table_entity = Table(
-            project_id="test-project",
-            dataset_id="test-dataset",
-            table_id="test-table"
+            project_id="source_project_id",
+            dataset_id="source_dataset_id",
+            table_id="source_table_id",
+            partition_id="123"
         )
         table_entity.put()
 
@@ -96,9 +97,10 @@ class TestAfterBackupActionHandler(unittest.TestCase):
              content('tests/json_samples/bigquery_v2_test_schema.json')),
         ])
         table_entity = Table(
-            project_id="test-project",
-            dataset_id="test-dataset",
-            table_id="test-table"
+            project_id="source_project_id",
+            dataset_id="source_dataset_id",
+            table_id="source_table_id",
+            partition_id="123"
         )
         table_entity.put()
 
@@ -137,9 +139,10 @@ class TestAfterBackupActionHandler(unittest.TestCase):
         ])
 
         table_entity = Table(
-            project_id="test-project",
-            dataset_id="test-dataset",
-            table_id="test-table"
+            project_id="source_project_id",
+            dataset_id="source_dataset_id",
+            table_id="source_table_id",
+            partition_id="123"
         )
         table_entity.put()
 
@@ -175,9 +178,10 @@ class TestAfterBackupActionHandler(unittest.TestCase):
             self, disable_partition_expiration, _, _1, _2, _3, _4):
         # given
         table_entity = Table(
-            project_id="test-project",
-            dataset_id="test-dataset",
-            table_id="test-table"
+            project_id="source_project_id",
+            dataset_id="source_dataset_id",
+            table_id="source_table_id",
+            partition_id="123"
         )
         table_entity.put()
 

--- a/tests/backup/test_table_backup.py
+++ b/tests/backup/test_table_backup.py
@@ -5,7 +5,6 @@ from google.appengine.ext import testbed, ndb
 from mock import patch, Mock
 
 from src.big_query.big_query_table_metadata import BigQueryTableMetadata
-from src.big_query.big_query import BigQuery
 from src.backup.backup_process import BackupProcess
 from src.backup.table_backup import TableBackup
 from src.backup.table_partitions_backup_scheduler import \
@@ -28,7 +27,7 @@ class TestTableBackup(unittest.TestCase):
     def tearDown(self):
         self.testbed.deactivate()
 
-
+    @patch('src.big_query.big_query.BigQuery.__init__', Mock(return_value=None))
     @patch.object(TablePartitionsBackupScheduler, 'start')
     @patch.object(BigQueryTableMetadata, 'get_table_by_reference', return_value=BigQueryTableMetadata(None))
     @patch.object(BigQueryTableMetadata, 'is_daily_partitioned', return_value=True)
@@ -47,6 +46,7 @@ class TestTableBackup(unittest.TestCase):
         # then
         table_partitions_backup_scheduler.assert_called_once()
 
+    @patch('src.big_query.big_query.BigQuery.__init__', Mock(return_value=None))
     @patch.object(BigQueryTableMetadata, 'get_table_by_reference', return_value=BigQueryTableMetadata(None))
     @patch.object(BigQueryTableMetadata, 'is_daily_partitioned', return_value=False)
     @patch.object(BackupProcess, 'start')
@@ -64,6 +64,7 @@ class TestTableBackup(unittest.TestCase):
         # then
         backup_start.assert_called_once()
 
+    @patch('src.big_query.big_query.BigQuery.__init__', Mock(return_value=None))
     @patch.object(BigQueryTableMetadata, 'get_table_by_reference', return_value=BigQueryTableMetadata(None))
     @patch.object(BigQueryTableMetadata, 'is_daily_partitioned', return_value=True)
     @patch.object(BigQueryTableMetadata, 'is_empty', return_value=True)

--- a/tests/big_query/test_big_query_table_metadata.py
+++ b/tests/big_query/test_big_query_table_metadata.py
@@ -4,6 +4,7 @@ import unittest
 from google.appengine.ext import testbed
 # nopep8 pylint: disable=C0301
 from mock import patch
+from mock.mock import Mock
 
 from src.big_query.big_query_table_metadata import BigQueryTableMetadata
 from src.big_query.big_query import BigQuery
@@ -24,6 +25,7 @@ class TestBigQueryTableMetadata_CreateTheSameEmptyTable(unittest.TestCase):
         # patch.stopall()
         self.testbed.deactivate()
 
+    @patch('src.big_query.big_query.BigQuery.__init__', Mock(return_value=None))
     @patch.object(BigQuery, 'create_table')
     def test_create_same_empty_table_execute_a_proper_big_query_request_with_same_table_properties(self, create_table):
         self.testbed = testbed.Testbed()
@@ -71,6 +73,7 @@ class TestBigQueryTableMetadata_GetTableByReferenceCached(unittest.TestCase):
         # patch.stopall()
         self.testbed.deactivate()
 
+    @patch('src.big_query.big_query.BigQuery.__init__', Mock(return_value=None))
     @patch.object(BigQuery, 'get_table', return_value={})
     def test_get_table_cached_should_only_call_bq_once(self, get_table):
         # given


### PR DESCRIPTION
… backup table in Big Query (not source table).

Now, bbq is querying for backup table metadata (instead of source table). Thanks to that, numBytes shows exact number of Bytes for backupTable - it makes our Datastore entries more consistent (earlier numBytes could change between copyJob start and creating Backup entity).

Note: as targetTableId doesn't contains partition, above imoplementation seems to be invalid, but we always backup partition into their own table -> so size of whole table equals to size of single partition in case of backups.

Some refactorings (using data from copyJob configuration).

Update unit tests to be consistent (the same data in 'given part' and in used CopyJobResult example)