### PR TITLE
Tables without defined schemas should not be scheduled for backup as …

### DIFF
--- a/src/backup/should_backup_predicate.py
+++ b/src/backup/should_backup_predicate.py
@@ -12,6 +12,9 @@ class ShouldBackupPredicate(object):
         if not self.big_query_table_metadata.table_exists():
             logging.info('Table not found (404)')
             return False
+        if not self.big_query_table_metadata.is_schema_defined():
+            logging.info('This table is without schema')
+            return False
         if self.big_query_table_metadata.is_empty():
             logging.info('This table is empty')
         if self.big_query_table_metadata.is_external_or_view_type():

--- a/src/big_query/big_query.py
+++ b/src/big_query/big_query.py
@@ -183,12 +183,10 @@ class BigQuery(object):  # pylint: disable=R0904
             ).execute(num_retries=3)
 
             if log_table and table:
-                table_copy = table.copy()
-                if 'schema' in table_copy:
-                    del table_copy['schema']
-                logging.info("Table: " + json.dumps(table_copy))
+                self.__log_table(table)
 
             return table
+
         except HttpError as ex:
             if ex.resp.status == 404:
                 logging.warning(
@@ -203,6 +201,12 @@ class BigQuery(object):  # pylint: disable=R0904
                 return None
             else:
                 raise ex
+
+    def __log_table(self, table):
+        table_copy = table.copy()
+        if 'schema' in table_copy:
+            del table_copy['schema']
+        logging.info("Table: " + json.dumps(table_copy))
 
     @retry(HttpError, tries=6, delay=2, backoff=2)
     def get_dataset(self, project_id, dataset_id):

--- a/src/big_query/big_query_table_metadata.py
+++ b/src/big_query/big_query_table_metadata.py
@@ -97,6 +97,12 @@ class BigQueryTableMetadata(object):
     def is_localized_in_EU(self):
         return self.get_location() == 'EU'
 
+    def is_schema_defined(self):
+        schema = self.table_metadata.get("schema")
+        if schema:
+            return True
+        return False
+
     def is_daily_partitioned(self):
         if self.table_metadata and 'timePartitioning' in self.table_metadata:
             if self.is_partition():

--- a/tests/backup/test_should_backup_predicate.py
+++ b/tests/backup/test_should_backup_predicate.py
@@ -27,6 +27,8 @@ class TestShouldBackupPredicate(unittest.TestCase):
               return_value=False).start()
         patch('src.big_query.big_query_table_metadata.BigQueryTableMetadata.'
               'is_external_or_view_type', return_value=False).start()
+        patch('src.big_query.big_query_table_metadata.BigQueryTableMetadata.'
+              'is_schema_defined', return_value=True).start()
 
     def initTestBedForDatastore(self):
         self.testbed = testbed.Testbed()
@@ -38,6 +40,16 @@ class TestShouldBackupPredicate(unittest.TestCase):
     def tearDown(self):
         self.testbed.deactivate()
         patch.stopall()
+
+    @patch.object(BigQueryTableMetadata, 'is_schema_defined', return_value=False)
+    def test_should_return_false_if_schema_is_not_defined(self, _):
+        # given
+        predicate = ShouldBackupPredicate(self.big_query_table_metadata)
+        # when
+        result = predicate.test(self.table)
+        # then
+        self.assertFalse(result, "ShouldBackupPredicate should return FALSE "
+                                "if table has no schema")
 
     @patch.object(BigQueryTableMetadata, 'is_empty', return_value=True)
     @patch.object(BigQueryTableMetadata, 'get_last_modified_datetime',

--- a/tests/big_query/test_big_query_table_metadata.py
+++ b/tests/big_query/test_big_query_table_metadata.py
@@ -85,6 +85,7 @@ class TestBigQueryTableMetadata_GetTableByReferenceCached(unittest.TestCase):
 
 
 class TestBigQueryTableMetadata_TableExists(unittest.TestCase):
+
     def test_should_return_true_if_json_is_None(self):
         # given
         big_query_table_metadata = BigQueryTableMetadata(None)
@@ -104,6 +105,7 @@ class TestBigQueryTableMetadata_TableExists(unittest.TestCase):
 
 # is_external_or_view_type() method tests
 class TestBigQueryTableMetadata_IsExternalOrViewType(unittest.TestCase):
+
     def test_should_return_true_if_EXTERNAL_type(self):
         # given
         big_query_table_metadata = BigQueryTableMetadata({"type":"EXTERNAL"})
@@ -226,6 +228,7 @@ class TestBigQueryTableMetadata_GetLocation(unittest.TestCase):
 
 # is_localized_in_EU() method tests
 class TestBigQueryTableMetadata_IsLocalizedInEU(unittest.TestCase):
+
     def test_should_return_TRUE_if_dataset_is_localized_in_EU(self):
         # given
         big_query_table_metadata = BigQueryTableMetadata({"location": "EU"})
@@ -253,8 +256,38 @@ class TestBigQueryTableMetadata_IsLocalizedInEU(unittest.TestCase):
         self.assertFalse(result)
 
 
+# is_schema_defined() method tests
+class TestBigQueryTableMetadata_IsSchemaDefined(unittest.TestCase):
+
+    def test_should_return_True_if_schema_exists(self):
+        # given
+        big_query_table_metadata = BigQueryTableMetadata({"schema": {
+            "fields": [
+                {
+                    "name": "Field_1",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                }
+            ]
+        }})
+        # when
+        result = big_query_table_metadata.is_schema_defined()
+        # then
+        self.assertTrue(result)
+
+    def test_should_return_False_if_schema_doesnt_exist(
+        self):
+        # given
+        # without schema field
+        big_query_table_metadata = BigQueryTableMetadata({})
+        # when
+        result = big_query_table_metadata.is_schema_defined()
+        # then
+        self.assertFalse(result)
+
 # is_daily_partitionded() method tests
 class TestBigQueryTableMetadata_IsDailyPartitioned(unittest.TestCase):
+
     def setUp(self):
         patch(
             'src.environment.Environment.version_id',


### PR DESCRIPTION
…not having schema produces error during copyJob.

Now, during evaluating predicate if backup or not, the fact if given table has defined schema is checked.