### PR TITLE
YACHT-972: Each partition of empty partitioned table is now backed up.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ In such scenario we're not able to restore data using BigQuery build-in features
 * [external data sources](https://cloud.google.com/bigquery/external-data-sources),
 * Views (you can use [GCP Census](https://github.com/ocadotechnology/gcp-census) for that),
 * Dataset/table labels as they are not copied by BigQuery copy job (again, you can use [GCP Census](https://github.com/ocadotechnology/gcp-census) for that)
+* Empty partitioned tables without any partitions. 
 
 ### Known caveats
 * Modification of table metadata (including table description) qualifies table to be backed up at the next cycle. It can be a problem for partitioned tables, where such change updates last modified time in every partition. Then BBQ will backup all partitions again, even though there was no actually change in partition data,

--- a/src/backup/table_backup.py
+++ b/src/backup/table_backup.py
@@ -15,7 +15,8 @@ class TableBackup(object):
 
         big_query_table_metadata = BigQueryTableMetadata.get_table_by_reference(table_reference)
 
-        if big_query_table_metadata.is_daily_partitioned():
+        if big_query_table_metadata.is_daily_partitioned() and \
+            not big_query_table_metadata.is_single_partition():
             logging.info('Table (%s/%s/%s) is partitioned',
                          table_reference.get_project_id(),
                          table_reference.get_dataset_id(),

--- a/src/backup/table_backup.py
+++ b/src/backup/table_backup.py
@@ -16,7 +16,7 @@ class TableBackup(object):
         big_query_table_metadata = BigQueryTableMetadata.get_table_by_reference(table_reference)
 
         if big_query_table_metadata.is_daily_partitioned() and \
-            not big_query_table_metadata.is_single_partition():
+            not big_query_table_metadata.is_partition():
             logging.info('Table (%s/%s/%s) is partitioned',
                          table_reference.get_project_id(),
                          table_reference.get_dataset_id(),

--- a/src/backup/table_backup.py
+++ b/src/backup/table_backup.py
@@ -15,8 +15,7 @@ class TableBackup(object):
 
         big_query_table_metadata = BigQueryTableMetadata.get_table_by_reference(table_reference)
 
-        if big_query_table_metadata.is_daily_partitioned() \
-                and not big_query_table_metadata.is_empty():
+        if big_query_table_metadata.is_daily_partitioned():
             logging.info('Table (%s/%s/%s) is partitioned',
                          table_reference.get_project_id(),
                          table_reference.get_dataset_id(),

--- a/src/commons/big_query/big_query_table_metadata.py
+++ b/src/commons/big_query/big_query_table_metadata.py
@@ -116,7 +116,7 @@ class BigQueryTableMetadata(object):
 
         return False
 
-    def is_single_partition(self):
+    def is_partition(self):
         table_id = self.table_metadata['tableReference']['tableId']
         return '$' in table_id
 
@@ -124,7 +124,7 @@ class BigQueryTableMetadata(object):
         return 'timePartitioning' in self.table_metadata
 
     def get_partition_id(self):
-        assert self.is_single_partition() == True
+        assert self.is_partition() == True
         table_id = self.table_metadata['tableReference']['tableId']
         return table_id.split('$')[1]
 
@@ -134,7 +134,7 @@ class BigQueryTableMetadata(object):
 
     def table_reference(self):
         table_reference = self.table_metadata['tableReference']
-        if self.is_single_partition():
+        if self.is_partition():
             return TableReference(table_reference['projectId'],
                                   table_reference['datasetId'],
                                   self.get_table_id(), self.get_partition_id())

--- a/src/commons/big_query/big_query_table_metadata.py
+++ b/src/commons/big_query/big_query_table_metadata.py
@@ -105,8 +105,6 @@ class BigQueryTableMetadata(object):
 
     def is_daily_partitioned(self):
         if self.table_metadata and 'timePartitioning' in self.table_metadata:
-            if self.is_partition():
-                return False
             time_partitioning = self.table_metadata['timePartitioning']
             if 'type' in time_partitioning:
                 type_of_partitioning = time_partitioning['type']
@@ -118,7 +116,7 @@ class BigQueryTableMetadata(object):
 
         return False
 
-    def is_partition(self):
+    def is_single_partition(self):
         table_id = self.table_metadata['tableReference']['tableId']
         return '$' in table_id
 
@@ -126,7 +124,7 @@ class BigQueryTableMetadata(object):
         return 'timePartitioning' in self.table_metadata
 
     def get_partition_id(self):
-        assert self.is_partition() == True
+        assert self.is_single_partition() == True
         table_id = self.table_metadata['tableReference']['tableId']
         return table_id.split('$')[1]
 
@@ -136,7 +134,7 @@ class BigQueryTableMetadata(object):
 
     def table_reference(self):
         table_reference = self.table_metadata['tableReference']
-        if self.is_partition():
+        if self.is_single_partition():
             return TableReference(table_reference['projectId'],
                                   table_reference['datasetId'],
                                   self.get_table_id(), self.get_partition_id())

--- a/src/restore/test/table_randomizer.py
+++ b/src/restore/test/table_randomizer.py
@@ -42,7 +42,7 @@ class TableRandomizer(object):
                           "It is possible that last backup cycle did not cover"
                           " it. Therefore restoration of this table can fail.")
 
-        if table_metadata.is_daily_partitioned() and not table_metadata.is_empty():
+        if table_metadata.is_daily_partitioned() and not table_metadata.is_single_partition() and not table_metadata.is_empty():
             table_metadata = self.__get_random_partition(table_reference)
             logging.info(
                 "Table is partitioned. Partition chosen to be restored: %s",

--- a/src/restore/test/table_randomizer.py
+++ b/src/restore/test/table_randomizer.py
@@ -42,7 +42,7 @@ class TableRandomizer(object):
                           "It is possible that last backup cycle did not cover"
                           " it. Therefore restoration of this table can fail.")
 
-        if table_metadata.is_daily_partitioned() and not table_metadata.is_single_partition() and not table_metadata.is_empty():
+        if table_metadata.is_daily_partitioned():
             table_metadata = self.__get_random_partition(table_reference)
             logging.info(
                 "Table is partitioned. Partition chosen to be restored: %s",
@@ -54,6 +54,10 @@ class TableRandomizer(object):
         partitions = self.big_query.list_table_partitions(table_reference.project_id,
                                                           table_reference.dataset_id,
                                                           table_reference.table_id)
+        if not partitions:
+            raise DoesNotMeetSampleCriteriaException(
+                "Partitioned table without partitions. Nothing to restore.")
+
         random_partition = self.__get_random_item_of_the_list(partitions)
 
         new_table_reference = TableReference(table_reference.project_id, table_reference.dataset_id, table_reference.table_id, random_partition)

--- a/tests/backup/test_table_backup.py
+++ b/tests/backup/test_table_backup.py
@@ -68,9 +68,9 @@ class TestTableBackup(unittest.TestCase):
     @patch.object(BigQueryTableMetadata, 'get_table_by_reference', return_value=BigQueryTableMetadata(None))
     @patch.object(BigQueryTableMetadata, 'is_daily_partitioned', return_value=True)
     @patch.object(BigQueryTableMetadata, 'is_empty', return_value=True)
-    @patch.object(BackupProcess, 'start')
-    def test_that_table_backup_is_scheduled_for_empty_partitioned_table(
-            self, backup_start, _, _1, _2):
+    @patch.object(TablePartitionsBackupScheduler, 'start')
+    def test_that_backup_for_partitions_is_scheduled_for_empty_partitioned_table(
+            self, table_partitions_backup_scheduler, _, _1, _2):
         # given
         table_reference = TableReference(project_id="test-project",
                                          dataset_id="test-dataset",
@@ -81,4 +81,4 @@ class TestTableBackup(unittest.TestCase):
         TableBackup.start(table_reference)
 
         # then
-        backup_start.assert_called_once()
+        table_partitions_backup_scheduler.assert_called_once()

--- a/tests/backup/test_table_backup.py
+++ b/tests/backup/test_table_backup.py
@@ -31,7 +31,7 @@ class TestTableBackup(unittest.TestCase):
     @patch.object(BackupProcess, 'start')
     @patch.object(BigQueryTableMetadata, 'get_table_by_reference', return_value=BigQueryTableMetadata(None))
     @patch.object(BigQueryTableMetadata, 'is_daily_partitioned', return_value=True)
-    @patch.object(BigQueryTableMetadata, 'is_single_partition', return_value=True)
+    @patch.object(BigQueryTableMetadata, 'is_partition', return_value=True)
     @patch.object(BigQueryTableMetadata, 'is_empty', return_value=False)
     def test_that_backup_are_scheduled_for_non_empty_single_partition(
             self, _, _1, _2,_3, backup_start):
@@ -67,7 +67,7 @@ class TestTableBackup(unittest.TestCase):
     @patch('src.commons.big_query.big_query.BigQuery.__init__', Mock(return_value=None))
     @patch.object(BigQueryTableMetadata, 'get_table_by_reference', return_value=BigQueryTableMetadata(None))
     @patch.object(BigQueryTableMetadata, 'is_daily_partitioned', return_value=True)
-    @patch.object(BigQueryTableMetadata, 'is_single_partition', return_value=False)
+    @patch.object(BigQueryTableMetadata, 'is_partition', return_value=False)
     @patch.object(BigQueryTableMetadata, 'is_empty', return_value=False)
     @patch.object(TablePartitionsBackupScheduler, 'start')
     def test_that_backup_for_partitions_is_scheduled_for_partitioned_table(
@@ -87,7 +87,7 @@ class TestTableBackup(unittest.TestCase):
     @patch('src.commons.big_query.big_query.BigQuery.__init__', Mock(return_value=None))
     @patch.object(BigQueryTableMetadata, 'get_table_by_reference', return_value=BigQueryTableMetadata(None))
     @patch.object(BigQueryTableMetadata, 'is_daily_partitioned', return_value=True)
-    @patch.object(BigQueryTableMetadata, 'is_single_partition', return_value=False)
+    @patch.object(BigQueryTableMetadata, 'is_partition', return_value=False)
     @patch.object(BigQueryTableMetadata, 'is_empty', return_value=True)
     @patch.object(TablePartitionsBackupScheduler, 'start')
     def test_that_backup_for_partitions_is_scheduled_for_empty_partitioned_table(

--- a/tests/backup/test_table_backup.py
+++ b/tests/backup/test_table_backup.py
@@ -57,7 +57,6 @@ class TestTableBackup(unittest.TestCase):
                                          dataset_id="test-dataset",
                                          table_id="test-table",
                                          partition_id=None)
-
         # when
         TableBackup.start(table_reference)
 

--- a/tests/big_query/test_big_query_table_metadata.py
+++ b/tests/big_query/test_big_query_table_metadata.py
@@ -307,7 +307,7 @@ class TestBigQueryTableMetadata_IsDailyPartitioned(unittest.TestCase):
     def tearDown(self):
         patch.stopall()
 
-    def test_should_return_False_if_is_a_partition(self):
+    def test_should_return_True_if_is_a_partition(self):
         # given
         big_query_table_metadata = BigQueryTableMetadata(
             {"tableReference":
@@ -318,7 +318,7 @@ class TestBigQueryTableMetadata_IsDailyPartitioned(unittest.TestCase):
         # when
         result = big_query_table_metadata.is_daily_partitioned()
         # then
-        self.assertEqual(False, result)
+        self.assertEqual(True, result)
 
     def test_should_return_False_if_there_is_no_partitioning_field(self):
         # given
@@ -382,8 +382,8 @@ class TestBigQueryTableMetadata_IsDailyPartitioned(unittest.TestCase):
         self.assertEqual(False, result)
 
 
-# is_partition() method tests
-class TestBigQueryTableMetadata_IsPartition(unittest.TestCase):
+# is_single_partition() method tests
+class TestBigQueryTableMetadata_IsSinglePartition(unittest.TestCase):
 
     def test_should_return_true_for_partition(self):
         # given
@@ -395,7 +395,7 @@ class TestBigQueryTableMetadata_IsPartition(unittest.TestCase):
             }
         })
         # when
-        result = big_query_table_metadata.is_partition()
+        result = big_query_table_metadata.is_single_partition()
         # then
         self.assertEqual(True, result)
 
@@ -409,7 +409,7 @@ class TestBigQueryTableMetadata_IsPartition(unittest.TestCase):
             }
         })
         # when
-        result = big_query_table_metadata.is_partition()
+        result = big_query_table_metadata.is_single_partition()
         # then
         self.assertEqual(False, result)
 

--- a/tests/big_query/test_big_query_table_metadata.py
+++ b/tests/big_query/test_big_query_table_metadata.py
@@ -382,8 +382,8 @@ class TestBigQueryTableMetadata_IsDailyPartitioned(unittest.TestCase):
         self.assertEqual(False, result)
 
 
-# is_single_partition() method tests
-class TestBigQueryTableMetadata_IsSinglePartition(unittest.TestCase):
+# is_partition() method tests
+class TestBigQueryTableMetadata_IsPartition(unittest.TestCase):
 
     def test_should_return_true_for_partition(self):
         # given
@@ -395,7 +395,7 @@ class TestBigQueryTableMetadata_IsSinglePartition(unittest.TestCase):
             }
         })
         # when
-        result = big_query_table_metadata.is_single_partition()
+        result = big_query_table_metadata.is_partition()
         # then
         self.assertEqual(True, result)
 
@@ -409,7 +409,7 @@ class TestBigQueryTableMetadata_IsSinglePartition(unittest.TestCase):
             }
         })
         # when
-        result = big_query_table_metadata.is_single_partition()
+        result = big_query_table_metadata.is_partition()
         # then
         self.assertEqual(False, result)
 

--- a/tests/restore/test/test_table_randomizer.py
+++ b/tests/restore/test/test_table_randomizer.py
@@ -38,12 +38,13 @@ class TestTableRandomizer(unittest.TestCase):
     @patch.object(BigQueryTableMetadata, 'is_empty', return_value=False)
     @patch.object(BigQueryTableMetadata, 'get_last_modified_datetime')
     @patch.object(BigQueryTableMetadata, 'is_daily_partitioned', return_value=True)
+    @patch.object(BigQueryTableMetadata, 'is_single_partition', return_value=False)
     @patch.object(BigQuery, 'list_table_partitions')
     @patch.object(BigQueryTableMetadata, 'get_table_by_reference')
     @patch.object(random, 'randint', return_value=1)
     def test_return_random_partition_when_table_is_partitioned(
-            self, _, get_table_by_reference, list_table_partitions, _1,
-            get_last_modified_datetime, _2, _3, _4, fetch_random_table):
+            self, _, get_table_by_reference, list_table_partitions, _1,_2,
+            get_last_modified_datetime, _3, _4, _5, fetch_random_table):
         # given
         get_table_by_reference.return_value= BigQueryTableMetadata(None)
 

--- a/tests/restore/test/test_table_randomizer.py
+++ b/tests/restore/test/test_table_randomizer.py
@@ -38,7 +38,7 @@ class TestTableRandomizer(unittest.TestCase):
     @patch.object(BigQueryTableMetadata, 'is_empty', return_value=False)
     @patch.object(BigQueryTableMetadata, 'get_last_modified_datetime')
     @patch.object(BigQueryTableMetadata, 'is_daily_partitioned', return_value=True)
-    @patch.object(BigQueryTableMetadata, 'is_single_partition', return_value=False)
+    @patch.object(BigQueryTableMetadata, 'is_partition', return_value=False)
     @patch.object(BigQuery, 'list_table_partitions')
     @patch.object(BigQueryTableMetadata, 'get_table_by_reference')
     @patch.object(random, 'randint', return_value=1)


### PR DESCRIPTION
Earlier, empty but still partitioned table was backes up as not-partitoned one.  It caused a bug in situation when earlier partitions (and whole table in consequence was not empty) were not empty, and then after data deletion, BBQ doesn't update each partition, but instead creates new backup of whole table. It makes this backup unrestorable as we assume that at given point of time there shouldn't be any Table entites which has both X:Y.Z$null and X:Y.Z$any_partition entries.