### PR TITLE
YACHT-1092: Passing create/write dispostion via RestorationJob for As…

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -96,11 +96,11 @@ handlers:
   secure: always
   login: admin
 - url: /tasks/copy_job_async/copy_job
-  script: src.commons.copy_job_async.copy_job.copy_job_service_handler.app
+  script: src.commons.big_query.copy_job_async.copy_job.copy_job_service_handler.app
   secure: always
   login: admin
 - url: /tasks/copy_job_async/result_check
-  script: src.commons.copy_job_async.result_check.result_check_handler.app
+  script: src.commons.big_query.copy_job_async.result_check.result_check_handler.app
   secure: always
   login: admin
 - url: /cron/backup

--- a/src/restore/dataset/dataset_restore_service.py
+++ b/src/restore/dataset/dataset_restore_service.py
@@ -24,7 +24,10 @@ class _DatasetRestoreService(object):
             max_partition_days)
 
         try:
-            RestorationJob.create(restoration_job_id)
+            restoration_job_key = RestorationJob.create(
+                restoration_job_id,
+                create_disposition="CREATE_IF_NEEDED",
+                write_disposition="WRITE_EMPTY")
         except DuplicatedRestorationJobIdException:
             logging.warning(
                 "Trying to create RestorationJob with already existed restoration job id")
@@ -36,7 +39,7 @@ class _DatasetRestoreService(object):
             target_dataset_id=target_dataset_id,
             max_partition_days=max_partition_days)
 
-        AsyncBatchRestoreService().restore(restoration_job_id, restore_items)
+        AsyncBatchRestoreService().restore(restoration_job_key, restore_items)
 
 
 class DatasetRestoreService(_DatasetRestoreService):

--- a/src/restore/datastore/restoration_job.py
+++ b/src/restore/datastore/restoration_job.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 
 from google.appengine.ext import ndb
 
@@ -11,16 +10,23 @@ class DuplicatedRestorationJobIdException(Exception):
 class RestorationJob(ndb.Model):
     created = ndb.DateTimeProperty(indexed=True, auto_now_add=True)
     items_count = ndb.IntegerProperty(indexed=True)
+    create_disposition = ndb.StringProperty(indexed=True)
+    write_disposition = ndb.StringProperty(indexed=True)
 
     @classmethod
     @ndb.transactional
-    def create(cls, restoration_job_id):
+    def create(cls, restoration_job_id, create_disposition, write_disposition):
         already_exist = RestorationJob.get_by_id(restoration_job_id)
 
         if already_exist:
             raise DuplicatedRestorationJobIdException()
 
-        restoration_job = RestorationJob(id=restoration_job_id, items_count=0)
+        restoration_job = RestorationJob(
+            id=restoration_job_id,
+            items_count=0,
+            create_disposition=create_disposition,
+            write_disposition=write_disposition
+        )
         return restoration_job.put()
 
     @ndb.transactional

--- a/src/restore/list/backup_list_restore_service.py
+++ b/src/restore/list/backup_list_restore_service.py
@@ -47,11 +47,15 @@ class BackupListRestoreRequest(object):
 
 class BackupListRestoreService(object):
     def restore(self, restoration_job_id, backup_list_restore_request):
-        RestorationJob.create(restoration_job_id)
+        restoration_job_key = RestorationJob.create(
+            restoration_job_id,
+            create_disposition="CREATE_IF_NEEDED",
+            write_disposition="WRITE_EMPTY"
+        )
         restore_items = self \
             .__generate_restore_items(backup_list_restore_request)
 
-        AsyncBatchRestoreService().restore(restoration_job_id, [restore_items])
+        AsyncBatchRestoreService().restore(restoration_job_key, [restore_items])
 
     @log_time
     def __generate_restore_items(self, backup_list_restore_request):

--- a/src/restore/status/restoration_job_status_service.py
+++ b/src/restore/status/restoration_job_status_service.py
@@ -28,6 +28,8 @@ class RestorationJobStatusService(object):
                 "status": status,
                 "itemResults": item_results,
                 "itemsCount": restoration_job.items_count,
+                "createDisposition": restoration_job.create_disposition,
+                "writeDisposition": restoration_job.write_disposition,
                 "restorationItems": restoration_items}
 
     @staticmethod

--- a/tests/restore/dataset/test_dataset_restore_service.py
+++ b/tests/restore/dataset/test_dataset_restore_service.py
@@ -1,12 +1,11 @@
-from unittest import TestCase
-
 from freezegun import freeze_time
 from google.appengine.ext import testbed, ndb
 from mock import patch, PropertyMock, ANY
+from unittest import TestCase
 
 from src.commons.config.configuration import Configuration
 from src.restore.dataset.dataset_restore_service import _DatasetRestoreService, \
-    DatasetRestoreService
+  DatasetRestoreService
 
 RESTORATION_JOB_ID = 'restoration_job_id'
 
@@ -106,8 +105,9 @@ class TestDatasetRestoreService(TestCase):
                                      dataset_id=DATASET_TO_RESTORE,
                                      target_dataset_id=None,
                                      max_partition_days=None)
-        self.restore_service.restore.assert_called_once_with(RESTORATION_JOB_ID,
-                                                             "<GENERATED ITEMS>")
+        self.restore_service.restore.assert_called_once_with(
+            ndb.Key('RestorationJob', RESTORATION_JOB_ID),
+            "<GENERATED ITEMS>")
 
     def test_should_not_call_async_service_twice_if_restoration_job_exist(
             self):
@@ -123,5 +123,6 @@ class TestDatasetRestoreService(TestCase):
                                          target_dataset_id=None,
                                          max_partition_days=None)
         # then
-        self.restore_service.restore.assert_called_once_with(RESTORATION_JOB_ID,
-                                                             ANY)
+        self.restore_service.restore.assert_called_once_with(
+            ndb.Key('RestorationJob', RESTORATION_JOB_ID),
+            ANY)

--- a/tests/restore/datastore/test_restoration_job.py
+++ b/tests/restore/datastore/test_restoration_job.py
@@ -1,6 +1,6 @@
 import unittest
-
 from datetime import datetime
+
 from freezegun import freeze_time
 from google.appengine.ext import ndb, testbed
 
@@ -8,6 +8,8 @@ from src.restore.datastore.restoration_job import RestorationJob, \
     DuplicatedRestorationJobIdException
 
 TEST_RESTORATION_JOB_ID = "111"
+CREATE_DISPOSITION = "CREATE_IF_NEEDED"
+WRITE_DISPOSITION = "WRITE_EMPTY"
 
 
 class TestRestorationJob(unittest.TestCase):
@@ -24,21 +26,47 @@ class TestRestorationJob(unittest.TestCase):
 
     def test_restoration_job_saved_in_datastore(self):
         # when
-        RestorationJob.create(restoration_job_id=TEST_RESTORATION_JOB_ID)
+        RestorationJob.create(restoration_job_id=TEST_RESTORATION_JOB_ID,
+                              create_disposition=CREATE_DISPOSITION,
+                              write_disposition=WRITE_DISPOSITION)
         # then
         self.assertIsNotNone(RestorationJob.get_by_id(TEST_RESTORATION_JOB_ID))
 
     def test_restoration_job_has_initial_count_0(self):
         # when
-        RestorationJob.create(restoration_job_id=TEST_RESTORATION_JOB_ID)
+        RestorationJob.create(restoration_job_id=TEST_RESTORATION_JOB_ID,
+                              create_disposition=CREATE_DISPOSITION,
+                              write_disposition=WRITE_DISPOSITION)
         # then
         self.assertEqual(
             RestorationJob.get_by_id(TEST_RESTORATION_JOB_ID).items_count, 0)
 
+    def test_restoration_job_has_passed_write_disposition(self):
+        # when
+        RestorationJob.create(restoration_job_id=TEST_RESTORATION_JOB_ID,
+                              create_disposition=CREATE_DISPOSITION,
+                              write_disposition=WRITE_DISPOSITION)
+        # then
+        self.assertEqual(
+            RestorationJob.get_by_id(TEST_RESTORATION_JOB_ID).write_disposition,
+            WRITE_DISPOSITION)
+
+    def test_restoration_job_has_passed_create_disposition(self):
+        # when
+        RestorationJob.create(restoration_job_id=TEST_RESTORATION_JOB_ID,
+                              create_disposition=CREATE_DISPOSITION,
+                              write_disposition=WRITE_DISPOSITION)
+        # then
+        self.assertEqual(
+            RestorationJob.get_by_id(TEST_RESTORATION_JOB_ID).create_disposition,
+            CREATE_DISPOSITION)
+
     @freeze_time("2012-01-14 03:21:34")
     def test_restoration_job_has_now_as_initial_created_time(self):
         # when
-        RestorationJob.create(restoration_job_id=TEST_RESTORATION_JOB_ID)
+        RestorationJob.create(restoration_job_id=TEST_RESTORATION_JOB_ID,
+                              create_disposition=CREATE_DISPOSITION,
+                              write_disposition=WRITE_DISPOSITION)
         # then
         self.assertEqual(
             RestorationJob.get_by_id(TEST_RESTORATION_JOB_ID).created,
@@ -47,7 +75,9 @@ class TestRestorationJob(unittest.TestCase):
     def test_restoration_job_return_entity_key(self):
         # when
         entity_key = RestorationJob.create(
-            restoration_job_id=TEST_RESTORATION_JOB_ID)
+            restoration_job_id=TEST_RESTORATION_JOB_ID,
+            create_disposition=CREATE_DISPOSITION,
+            write_disposition=WRITE_DISPOSITION)
         # then
         self.assertIsNotNone(entity_key.get())
 
@@ -72,10 +102,19 @@ class TestRestorationJob(unittest.TestCase):
 
     def test_create_if_not_exist_should_throw_exception_if_already_exist(self):
         # given
-        RestorationJob.create(TEST_RESTORATION_JOB_ID)
+        RestorationJob.create(
+            restoration_job_id=TEST_RESTORATION_JOB_ID,
+            create_disposition=CREATE_DISPOSITION,
+            write_disposition=WRITE_DISPOSITION)
         # when then
         with self.assertRaises(DuplicatedRestorationJobIdException):
-            RestorationJob.create(TEST_RESTORATION_JOB_ID)
+            RestorationJob.create(
+                restoration_job_id=TEST_RESTORATION_JOB_ID,
+                create_disposition=CREATE_DISPOSITION,
+                write_disposition=WRITE_DISPOSITION)
 
     def __create_restoration_job(self):
-        return RestorationJob.create(TEST_RESTORATION_JOB_ID).get()
+        return RestorationJob.create(
+            restoration_job_id=TEST_RESTORATION_JOB_ID,
+            create_disposition=CREATE_DISPOSITION,
+            write_disposition=WRITE_DISPOSITION).get()

--- a/tests/restore/datastore/test_restore_item.py
+++ b/tests/restore/datastore/test_restore_item.py
@@ -136,8 +136,11 @@ class TestRestoreItem(unittest.TestCase):
         self.assertEqual(updated_restore_item.status_message, error_message)
 
     @staticmethod
-    def __create_restoration_job_with_one_item(restoration_job):
-        restoration_job_key = RestorationJob.create(restoration_job)
+    def __create_restoration_job_with_one_item(restoration_job_id):
+        restoration_job_key = RestorationJob.create(
+            restoration_job_id=restoration_job_id,
+            create_disposition="CREATE_IF_NEEDED",
+            write_disposition="WRITE_EMPTY")
         restoration_job_key.get().increment_count_by(1)
 
         restore_item = TestRestoreItem.__create_restore_item_example(

--- a/tests/restore/list/test_backup_list_restore_service.py
+++ b/tests/restore/list/test_backup_list_restore_service.py
@@ -3,15 +3,15 @@ import unittest
 from google.appengine.ext import testbed, ndb
 from mock import patch, PropertyMock
 
-from src.commons.exceptions import ParameterValidationException
 from src.backup.datastore.Backup import Backup
 from src.backup.datastore.Table import Table
 from src.commons.config.configuration import Configuration
+from src.commons.exceptions import ParameterValidationException
+from src.commons.table_reference import TableReference
 from src.restore.async_batch_restore_service import AsyncBatchRestoreService
 from src.restore.datastore.restore_item import RestoreItem
 from src.restore.list.backup_list_restore_service import \
-    BackupItem, BackupListRestoreRequest, BackupListRestoreService
-from src.commons.table_reference import TableReference
+  BackupItem, BackupListRestoreRequest, BackupListRestoreService
 
 
 class TestBackupListRestoreService(unittest.TestCase):
@@ -71,7 +71,10 @@ class TestBackupListRestoreService(unittest.TestCase):
 
         # then
         mocked_restore_service.assert_called_once()
-        mocked_restore_service.assert_called_with("restorationId", [[expected_restore_item]])
+        mocked_restore_service.assert_called_with(
+            ndb.Key('RestorationJob', 'restorationId'),
+            [[expected_restore_item]]
+        )
 
     @patch.object(AsyncBatchRestoreService, 'restore',
                   return_value="restorationId")
@@ -110,7 +113,10 @@ class TestBackupListRestoreService(unittest.TestCase):
 
         # then
         mocked_restore_service.assert_called_once()
-        mocked_restore_service.assert_called_with("restorationId", [[expected_restore_item]])
+        mocked_restore_service.assert_called_with(
+            ndb.Key('RestorationJob', 'restorationId'),
+            [[expected_restore_item]]
+        )
 
     def test_that_restore_will_fail_if_backup_not_exists_in_ds(self):
         # given

--- a/tests/restore/status/test_restoration_job_status_service.py
+++ b/tests/restore/status/test_restoration_job_status_service.py
@@ -198,7 +198,9 @@ class TestRestorationJobStatusService(unittest.TestCase):
         self.assertEqual(3, len(result['restorationItems']))
 
     def create_restoration_job_with_count(self, item_count):
-        job_key = RestorationJob.create(TEST_RESTORATION_JOB_ID)
+        job_key = RestorationJob.create(TEST_RESTORATION_JOB_ID,
+                                        create_disposition="CREATE_IF_NEEDED",
+                                        write_disposition="WRITE_EMPTY")
         job_key.get().increment_count_by(item_count)
         return job_key
 

--- a/tests/restore/test_async_restore_service.py
+++ b/tests/restore/test_async_restore_service.py
@@ -1,18 +1,17 @@
 import uuid
-from unittest import TestCase
 
+from apiclient.errors import HttpError
 from google.appengine.ext import testbed, ndb
 from mock import patch, call, mock
+from unittest import TestCase
 
 from src.commons.big_query.copy_job_async.post_copy_action_request \
-    import PostCopyActionRequest
+  import PostCopyActionRequest
+from src.commons.table_reference import TableReference
 from src.restore.async_batch_restore_service import AsyncBatchRestoreService
 from src.restore.datastore.restoration_job import RestorationJob
 from src.restore.datastore.restore_item import RestoreItem
 from src.restore.restore_workspace_creator import RestoreWorkspaceCreator
-from apiclient.errors import HttpError
-
-from src.commons.table_reference import TableReference
 
 HARDCODED_UUID = '123'
 
@@ -39,14 +38,17 @@ class TestAsyncRestoreService(TestCase):
 
     def test_for_single_item_should_create_post_copy_action(self):
         # given
-        RestorationJob.create(HARDCODED_UUID)
+        restoration_job_key = RestorationJob.create(
+            HARDCODED_UUID,
+            create_disposition="CREATE_IF_NEEDED",
+            write_disposition="WRITE_EMPTY")
         restore_items_tuple = self.__create_restore_items(count=1)
         restore_item = restore_items_tuple[0][0]
         source_bq = restore_items_tuple[0][1].create_big_query_table()
         target_bq = restore_items_tuple[0][2].create_big_query_table()
 
         # when
-        AsyncBatchRestoreService().restore(HARDCODED_UUID, [[restore_item]])
+        AsyncBatchRestoreService().restore(restoration_job_key, [[restore_item]])
 
         # then
         self.copy_service.assert_has_calls(
@@ -59,7 +61,9 @@ class TestAsyncRestoreService(TestCase):
                             'restoreItemKey': (
                                 restore_item.key.urlsafe())
                         })),
-                call().with_post_action().copy_table(source_bq, target_bq)
+                call().with_post_action().with_create_disposition('CREATE_IF_NEEDED'),
+                call().with_post_action().with_create_disposition().with_write_disposition('WRITE_EMPTY'),
+                call().with_post_action().with_create_disposition().with_write_disposition().copy_table(source_bq, target_bq)
             ])
 
     @patch.object(RestoreWorkspaceCreator, 'create_workspace', side_effect=
@@ -67,12 +71,12 @@ class TestAsyncRestoreService(TestCase):
     def test_failing_creating_dataset_should_update_restore_item_status(self,
         _):
         # given
-        restoration_job_key = RestorationJob.create(HARDCODED_UUID)
+        restoration_job_key = RestorationJob.create(HARDCODED_UUID, create_disposition="CREATE_IF_NEEDED", write_disposition="WRITE_EMPTY")
         restore_items_tuple = self.__create_restore_items(count=1)
         restore_item = restore_items_tuple[0][0]
 
         # when
-        AsyncBatchRestoreService().restore(HARDCODED_UUID, [[restore_item]])
+        AsyncBatchRestoreService().restore(restoration_job_key, [[restore_item]])
 
         # then
         restore_items = list(RestoreItem.query().filter(
@@ -83,7 +87,10 @@ class TestAsyncRestoreService(TestCase):
 
     def test_multiple_items_restore(self):
         # given
-        RestorationJob.create(HARDCODED_UUID)
+        restoration_job_key = RestorationJob.create(
+            HARDCODED_UUID,
+            create_disposition="CREATE_IF_NEEDED",
+            write_disposition="WRITE_EMPTY")
         restore_items_tuple = self.__create_restore_items(count=2)
         restore_item1 = restore_items_tuple[0][0]
         restore_item2 = restore_items_tuple[1][0]
@@ -92,7 +99,7 @@ class TestAsyncRestoreService(TestCase):
         source_bq2 = restore_items_tuple[1][1].create_big_query_table()
         target_bq2 = restore_items_tuple[1][2].create_big_query_table()
         # when
-        AsyncBatchRestoreService().restore(HARDCODED_UUID,
+        AsyncBatchRestoreService().restore(restoration_job_key,
                                            [[restore_items_tuple[0][0],
                                              restore_items_tuple[1][0]]])
 
@@ -105,7 +112,9 @@ class TestAsyncRestoreService(TestCase):
                              'restoreItemKey': (
                                  restore_item1.key.urlsafe())
                          })),
-                 call().with_post_action().copy_table(source_bq1, target_bq1),
+                 call().with_post_action().with_create_disposition('CREATE_IF_NEEDED'),
+                 call().with_post_action().with_create_disposition().with_write_disposition('WRITE_EMPTY'),
+                 call().with_post_action().with_create_disposition().with_write_disposition().copy_table(source_bq1, target_bq1),
                  call(copy_job_type_id='restore', task_name_suffix='123'),
                  call().with_post_action(
                      PostCopyActionRequest(
@@ -114,17 +123,19 @@ class TestAsyncRestoreService(TestCase):
                              'restoreItemKey': (
                                  restore_item2.key.urlsafe())
                          })),
-                 call().with_post_action().copy_table(source_bq2, target_bq2)
+                 call().with_post_action().with_create_disposition('CREATE_IF_NEEDED'),
+                 call().with_post_action().with_create_disposition().with_write_disposition('WRITE_EMPTY'),
+                 call().with_post_action().with_create_disposition().with_write_disposition().copy_table(source_bq2, target_bq2)
                  ]
         self.copy_service.assert_has_calls(calls)
 
     def test_that_enforcer_is_called_for_each_restore_item(self):
         # given
-        RestorationJob.create(HARDCODED_UUID)
+        restoration_job_key= RestorationJob.create(HARDCODED_UUID, create_disposition="CREATE_IF_NEEDED", write_disposition="WRITE_EMPTY")
         restore_items_tuple = self.__create_restore_items(count=2)
 
         # when
-        AsyncBatchRestoreService().restore(HARDCODED_UUID,
+        AsyncBatchRestoreService().restore(restoration_job_key,
                                            [[restore_items_tuple[0][0],
                                              restore_items_tuple[1][0]]])
 
@@ -138,10 +149,13 @@ class TestAsyncRestoreService(TestCase):
 
     def test_that_proper_entities_were_stored_in_datastore(self):
         # given
-        RestorationJob.create(HARDCODED_UUID)
+        restoration_job_key = RestorationJob.create(
+            HARDCODED_UUID,
+            create_disposition="CREATE_IF_NEEDED",
+            write_disposition="WRITE_EMPTY")
         restore_item_tuples = self.__create_restore_items(count=3)
         # when
-        AsyncBatchRestoreService().restore(HARDCODED_UUID,
+        AsyncBatchRestoreService().restore(restoration_job_key,
                                            [[restore_item_tuples[0][0],
                                              restore_item_tuples[1][0]],
                                             [restore_item_tuples[2][0]]])


### PR DESCRIPTION
…yncRestoreService (as it is common for whole restore). Updating paths in app.yaml.

Updating restore status to show write/create disposition.

Passing RestorationJob as object in parameters to avoid unnecessary calls to Datastore.