### PR TITLE
YACHT-1142: SLI Quality query finds also tables without backup table …

### DIFF
--- a/terraform/SLI_quality_views.tf
+++ b/terraform/SLI_quality_views.tf
@@ -119,6 +119,7 @@ resource "google_bigquery_table" "SLI_quality" {
             WHERE
               (source_table.numBytes != last_backup_in_census.backup_num_bytes
                 OR source_table.numRows != last_backup_in_census.backup_num_rows)
+              OR last_backup_in_census.backup_num_bytes IS NULL
         EOF
     use_legacy_sql = true
   }


### PR DESCRIPTION
…in BQ even if datastore has information about backup.

Null check for joined last table from census was added to find tables which backup could be removed from BQ (but infromation about backup stays in datastore like it would still exist).

Note: Quality SLI filtered out every table which was changed during last 3 days.
So only older tables which backup was deleted would be found.
Also, census recognises that table is removed after 3 days (after two snapshots), so in the worst case scenario, SLI would show that backup is lost after 6 days from removal.