### PR TITLE
YACHT-1142: SLI Quality query finds also tables without backup table …

### DIFF
--- a/slo-service.yaml
+++ b/slo-service.yaml
@@ -37,8 +37,12 @@ handlers:
   script: src.slo.backup_creation_latency.latency_sli_handler.app
   secure: always
   login: admin
-- url: /sli/quality.*
+- url: /sli/quality
   script: src.slo.backup_quality.quality_sli_handler.app
+  secure: always
+  login: admin
+- url: /sli/quality/violation
+  script: src.slo.backup_quality.quality_violation_sli_handler.app
   secure: always
   login: admin
 - url: /sli/latency/violation

--- a/src/slo/backup_quality/quality_query_specification.py
+++ b/src/slo/backup_quality/quality_query_specification.py
@@ -18,13 +18,13 @@ class QualityQuerySpecification(object):
                               "backupDatasetId": result['f'][4]['v'],
                               "backupTableId": result['f'][5]['v'],
                               "lastModifiedTime": float(result['f'][6]['v']),
-                              "backupLastModifiedTime": float(result['f'][7]['v']),
+                              "backupLastModifiedTime": float(result['f'][7]['v']) if result['f'][7]['v'] is not None else None,
                               "backupEntityLastModifiedTime": float(result['f'][8]['v']),
                               "numBytes": int(result['f'][9]['v']),
-                              "backupNumBytes": int(result['f'][10]['v']),
+                              "backupNumBytes": int(result['f'][10]['v']) if result['f'][10]['v'] is not None else None,
                               "backupEntityNumBytes": int(result['f'][11]['v']),
                               "numRows": int(result['f'][12]['v']),
-                              "backupNumRows": int(result['f'][13]['v'])
+                              "backupNumRows": int(result['f'][13]['v']) if result['f'][13]['v'] is not None else None,
                               } for result in results]
         return formatted_results
 

--- a/src/slo/backup_quality/quality_violation_sli_handler.py
+++ b/src/slo/backup_quality/quality_violation_sli_handler.py
@@ -9,7 +9,7 @@ class ViolationSliHandler(webapp2.RequestHandler):
     def post(self):
         json_data = JsonRequestHelper.parse_request_body(self.request.body)
         json_table = json_data['table']
-        QualityViolationSliService.check_and_stream_violation(json_table)
+        QualityViolationSliService().check_and_stream_violation(json_table)
 
 
 app = webapp2.WSGIApplication([

--- a/terraform/SLI_quality_views.tf
+++ b/terraform/SLI_quality_views.tf
@@ -49,8 +49,8 @@ resource "google_bigquery_table" "last_backup_in_census" {
               last_backup.source_partition_id AS source_partition_id,
               last_backup.backup_last_modified AS backup_entity_last_modified_time,
               last_backup.backup_num_bytes AS backup_entity_num_bytes,
-              census.datasetId AS backup_dataset_id,
-              census.tableId AS backup_table_id,
+              last_backup.backup_dataset_id AS backup_dataset_id,
+              last_backup.backup_table_id AS backup_table_id,
               census.lastModifiedTime as backup_last_modified,
               census.numBytes AS backup_num_bytes,
               census.numRows AS backup_num_rows
@@ -117,9 +117,10 @@ resource "google_bigquery_table" "SLI_quality" {
               AND source_table.tableId=last_backup_in_census.source_table_id
               AND source_table.partitionId=last_backup_in_census.source_partition_id
             WHERE
-              (source_table.numBytes != last_backup_in_census.backup_num_bytes
-                OR source_table.numRows != last_backup_in_census.backup_num_rows)
-              OR last_backup_in_census.backup_num_bytes IS NULL
+              last_backup_in_census.backup_table_id IS NOT NULL
+              AND (source_table.numBytes != last_backup_in_census.backup_num_bytes
+                   OR source_table.numRows != last_backup_in_census.backup_num_rows
+                   OR last_backup_in_census.backup_num_bytes IS NULL)
         EOF
     use_legacy_sql = true
   }


### PR DESCRIPTION
…in BQ even if datastore has information about backup.

1. last_backup_in_census view now uses data from datastore (for backup_dataset_id and backup_table_id) to avoid nulls when backup info exists in datastore but proper backup doesn't exist in BigQuery.

2. Handling null values in quality_query_specification. Values could be null if backup table doesn't exist in BigQuery. We want to find that cases.

3. Repairing handler paths for quality_violation_sli_handler. Repairing minor bugs.