### PR TITLE
YACHT-1142: SLI Quality query finds also tables without backup table …

### DIFF
--- a/src/slo/backup_quality/predicate/sli_bq_backup_exists_predicate.py
+++ b/src/slo/backup_quality/predicate/sli_bq_backup_exists_predicate.py
@@ -1,0 +1,12 @@
+import logging
+
+
+class SLIBQBackupExistsPredicate(object):
+
+    def exists(self, sli_table_entry):
+        if sli_table_entry["backupNumBytes"]:
+            logging.info("Table has backup table in BQ")
+            return True
+        else:
+            logging.info("Table doesn't have backup table in BQ")
+            return False

--- a/src/slo/backup_quality/quality_violation_sli_service.py
+++ b/src/slo/backup_quality/quality_violation_sli_service.py
@@ -1,6 +1,7 @@
 import logging
 
 from src.commons.big_query.big_query import BigQuery
+from src.slo.backup_quality.predicate.sli_bq_backup_exists_predicate import SLIBQBackupExistsPredicate
 from src.slo.predicate.sli_table_exists_predicate import \
     SLITableExistsPredicate
 from src.slo.backup_quality.quality_query_specification import \
@@ -23,6 +24,7 @@ class QualityViolationSliService(object):
         )
         self.table_newer_modification_predicate = SLITableNewerModificationPredicate(big_query)
         self.table_existence_predicate = SLITableExistsPredicate(big_query, QualityQuerySpecification)
+        self.bq_backup_existence_predicate = SLIBQBackupExistsPredicate()
 
     def check_and_stream_violation(self, json_table):
         if self.__should_stay_as_sli_violation(json_table):
@@ -31,6 +33,8 @@ class QualityViolationSliService(object):
 
     def __should_stay_as_sli_violation(self, table):
         try:
+            if not self.bq_backup_existence_predicate.exists(table):
+                return True
             if not self.table_existence_predicate.exists(table):
                 return False
             return not self.table_newer_modification_predicate.is_modified_since_last_census_snapshot(table)

--- a/tests/slo/predicate/test_sli_bq_backup_exists_predicate.py
+++ b/tests/slo/predicate/test_sli_bq_backup_exists_predicate.py
@@ -1,0 +1,62 @@
+import unittest
+
+from src.slo.backup_quality.predicate.sli_bq_backup_exists_predicate import SLIBQBackupExistsPredicate
+
+
+class TestSLITableExistsPredicate(unittest.TestCase):
+
+    def test_should_return_false_for_not_existing_backup_table(self):
+        # given
+        sli_table = self.__create_sli_table_without_backup_table()
+
+        # when
+        exists = SLIBQBackupExistsPredicate().exists(sli_table)
+
+        # then
+        self.assertFalse(exists)
+
+    def test_should_return_true_for_existing_backup_table(self):
+        # given
+        sli_table = self.__create_sli_table_with_backup_table()
+
+        # when
+        exists = SLIBQBackupExistsPredicate().exists(sli_table)
+
+        # then
+        self.assertTrue(exists)
+
+    def __create_sli_table_without_backup_table(self):
+        return {
+            "snapshotTime": None,
+            "projectId": 'p',
+            "datasetId": 'd',
+            "tableId": 'd',
+            "partitionId": '20180808',
+            "creationTime": '1500000000000',
+            "lastModifiedTime": None,
+            "backupCreated": None,
+            "backupLastModified": None,
+            "backupDatasetId": 'b_d',
+            "backupTableId": 'b_t',
+            "backupNumBytes": None,
+            "backupNumRows": None,
+            "xDays": 4
+        }
+
+    def __create_sli_table_with_backup_table(self):
+        return {
+            "snapshotTime": None,
+            "projectId": 'p',
+            "datasetId": 'd',
+            "tableId": 'd',
+            "partitionId": '20180808',
+            "creationTime": '1500000000000',
+            "lastModifiedTime": None,
+            "backupCreated": None,
+            "backupLastModified": None,
+            "backupDatasetId": 'b_d',
+            "backupTableId": 'b_t',
+            "backupNumBytes": 123456789,
+            "backupNumRows": 123456789,
+            "xDays": 4
+        }


### PR DESCRIPTION
…in BQ even if datastore has information about backup.

Adding additional predicate which prevents from filtering out tables which doesn't have backup table in BigQuery.
Additional units tests was added.