### PR TITLE
NON-JIRA: Cleaning unused old datastore entities during retention pro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Every day retention process scans all backups to find and delete backups matchin
 * if there are multiple backups per day, the most recent one is retained. Multiple backups per day are created in rare cases (e.g. when task queue task is executed more than one time),
 * for backups younger than 7 months, the 10 most recent ones are retained,
 * for backups older than 7 months, single most recent backup is retained,
-* if source table is deleted, then the last backup is deleted after 7 months after deletion.
+* if source table is deleted, then the last backup is deleted after 7 months after deletion,
+* one month after deletion of last backup, datastore entities for table and backups are deleted
  
 ### Example of 10 versions retention for backups younger than 7 months
 ![Retention process](docs/images/bbq_retention_process_10_versions.gif)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,3 +24,11 @@ project_settings:
 
   # default_restoration_project_id - project into which data will be restored by default during restoration process
   # default_restoration_project_id: 'default-restoration-storage-project-id'
+
+retention_settings:
+
+  # young_old_generation_threshold_in_months - number of months from above retention process will left only one backup older than
+  young_old_generation_threshold_in_months: 7
+
+  # grace_period_after_source_table_deletion_in_months - number of months since deletion of source table after retention will remove last backup for given table
+  grace_period_after_source_table_deletion_in_months: 7

--- a/src/backup/datastore/Backup.py
+++ b/src/backup/datastore/Backup.py
@@ -58,9 +58,16 @@ class Backup(ndb.Model):
     # nopep8 pylint: disable=C0121
     @classmethod
     @retry(Exception, tries=5, delay=1, backoff=2)
-    def get_all_backups_sorted(cls, ancestor_key):
+    def get_all_not_deleted_backups_sorted(cls, ancestor_key):
         return Backup.query(ancestor=ancestor_key) \
             .filter(ndb.GenericProperty('deleted') == None) \
+            .order(-Backup.created) \
+            .fetch()
+
+    @classmethod
+    @retry(Exception, tries=5, delay=1, backoff=2)
+    def get_all_backups_sorted(cls, ancestor_key):
+        return Backup.query(ancestor=ancestor_key) \
             .order(-Backup.created) \
             .fetch()
 

--- a/src/commons/config/configuration.py
+++ b/src/commons/config/configuration.py
@@ -46,6 +46,13 @@ class Configuration(object):
     def projects_to_skip(self):
         return self.__project_config['backup_settings'].get('projects_to_skip')
 
+    @property
+    def grace_period_after_source_table_deletion_in_months(self):
+        return self.__project_config['retention_settings'].get('grace_period_after_source_table_deletion_in_months')    \
+
+    @property
+    def young_old_generation_threshold_in_months(self):
+        return self.__project_config['retention_settings'].get('young_old_generation_threshold_in_months')
 
 config_file_yaml = "config/config.yaml"
 logging.info("Loading configuration from file: '%s'", config_file_yaml)

--- a/src/retention/policy/filter/grace_period_after_deletion_filter.py
+++ b/src/retention/policy/filter/grace_period_after_deletion_filter.py
@@ -5,10 +5,10 @@ from dateutil.relativedelta import relativedelta
 from apiclient.errors import HttpError
 
 from src.commons.big_query.big_query_table_metadata import BigQueryTableMetadata
+from src.commons.config.configuration import configuration
 
 
 class GracePeriodAfterDeletionFilter(object):
-    GRACE_PERIOD_AFTER_DELETION_IN_MONTHS = 7
 
     def filter(self, backups, table_reference):
         if self.__should_keep_backups(backups, table_reference):
@@ -18,7 +18,7 @@ class GracePeriodAfterDeletionFilter(object):
 
     def __should_keep_backups(self, backups, table_reference):
         age_threshold_date = datetime.date.today() - relativedelta(
-            months=self.GRACE_PERIOD_AFTER_DELETION_IN_MONTHS)
+            months=configuration.grace_period_after_source_table_deletion_in_months)
         old_backups = [b for b in backups
                        if b.created.date() < age_threshold_date]
 

--- a/src/retention/policy/filter/only_one_version_old_backup_filter.py
+++ b/src/retention/policy/filter/only_one_version_old_backup_filter.py
@@ -4,7 +4,7 @@ from src.retention.policy.filter.utils.backup_age_divider import \
     BackupAgeDivider
 
 
-class OnlyOneVersionAbove7MonthsFilter(object):
+class OnlyOneVersionForOldBackupFilter(object):
 
     def filter(self, backups, table_reference):
         sorted_backups = Backup.sort_backups_by_create_time_desc(backups)

--- a/src/retention/policy/filter/utils/backup_age_divider.py
+++ b/src/retention/policy/filter/utils/backup_age_divider.py
@@ -2,7 +2,7 @@ import datetime
 
 from dateutil.relativedelta import relativedelta
 
-NUMBER_OF_MONTHS_TO_KEEP = 7
+from src.commons.config.configuration import configuration
 
 
 class BackupAgeDivider(object):
@@ -10,7 +10,7 @@ class BackupAgeDivider(object):
     @staticmethod
     def divide_backups_by_age(backups):
         age_threshold_date = datetime.date.today() - relativedelta(
-            months=NUMBER_OF_MONTHS_TO_KEEP)
+            months=configuration.young_old_generation_threshold_in_months)
 
         young_backups = [b for b in backups
                          if b.created.date() >= age_threshold_date]

--- a/src/retention/policy/retention_policy.py
+++ b/src/retention/policy/retention_policy.py
@@ -4,17 +4,17 @@ from src.retention.policy.filter.grace_period_after_deletion_filter import \
     GracePeriodAfterDeletionFilter
 from src.retention.policy.filter.most_recent_daily_backup_filter import \
     MostRecentDailyBackupFilter
+from src.retention.policy.filter.only_one_version_old_backup_filter import \
+    OnlyOneVersionForOldBackupFilter
 from src.retention.policy.filter.ten_young_backup_versions_filter import \
     TenYoungBackupVersionsFilter
-from src.retention.policy.filter.only_one_version_above_7_months_filter import \
-    OnlyOneVersionAbove7MonthsFilter
 
 
 class RetentionPolicy(object):
     def __init__(self):
         self.filters = [MostRecentDailyBackupFilter(),
                         TenYoungBackupVersionsFilter(),
-                        OnlyOneVersionAbove7MonthsFilter(),
+                        OnlyOneVersionForOldBackupFilter(),
                         GracePeriodAfterDeletionFilter()]
 
     def get_backups_eligible_for_deletion(self, backups, table_reference):

--- a/src/retention/should_perform_datastore_cleanup_predicate.py
+++ b/src/retention/should_perform_datastore_cleanup_predicate.py
@@ -1,0 +1,32 @@
+import datetime
+
+from dateutil.relativedelta import relativedelta
+from google.appengine.ext import ndb
+
+from src.commons.config.configuration import configuration
+
+
+class ShouldPerformDatastoreCleanupPredicate(object):
+
+    @staticmethod
+    def test(url_safe_key, existing_backups):
+        if existing_backups:
+            return False
+        if ShouldPerformDatastoreCleanupPredicate.\
+                __is_table_deleted_before_threshold(url_safe_key):
+            return True
+        return False
+
+    @staticmethod
+    def __is_table_deleted_before_threshold(url_safe_key):
+        table = ndb.Key(urlsafe=url_safe_key).get()
+        deletion_threshold_in_months = \
+            configuration.grace_period_after_source_table_deletion_in_months + 1
+
+        age_threshold_date = \
+            datetime.datetime.now() - relativedelta(months=deletion_threshold_in_months)
+
+        if table.last_checked < age_threshold_date:
+            return True
+
+        return False

--- a/src/retention/table_retention.py
+++ b/src/retention/table_retention.py
@@ -6,9 +6,11 @@ from google.appengine.ext import ndb
 from src.backup.datastore.Backup import Backup
 from src.commons.big_query.big_query import TableNotFoundException, BigQuery
 from src.commons.config.configuration import configuration
+from src.commons.table_reference import TableReference
+from src.retention.should_perform_datastore_cleanup_predicate import \
+    ShouldPerformDatastoreCleanupPredicate
 from src.retention.should_perform_retention_predicate import \
     ShouldPerformRetentionPredicate
-from src.commons.table_reference import TableReference
 
 
 class TableRetention(object):
@@ -18,20 +20,20 @@ class TableRetention(object):
         self.policy = policy
 
     def perform_retention(self, table_reference, table_key):
-        backups = Backup.get_all_backups_sorted(ndb.Key(urlsafe=table_key))
+        backups = Backup.get_all_not_deleted_backups_sorted(
+            ndb.Key(urlsafe=table_key))
         logging.debug("Fetched %s backups for the table: %s", len(backups),
                       table_reference)
 
-        if not ShouldPerformRetentionPredicate.test(backups):
-            return
-
-        logging.info("Retention policy used for table '%s': '%s'",
-                     table_reference, type(self.policy).__name__)
-
-        for backup in self.policy\
-                .get_backups_eligible_for_deletion(backups=backups,
-                                                   table_reference=table_reference):
-            self.__delete_backup_in_bq_and_update_datastore(backup)
+        if ShouldPerformRetentionPredicate.test(backups):
+            logging.info("Performing retention for table '%s'", table_reference)
+            for backup in self.policy.get_backups_eligible_for_deletion(
+                    backups=backups,
+                    table_reference=table_reference
+            ):
+                self.__delete_backup_in_bq_and_update_datastore(backup)
+        elif ShouldPerformDatastoreCleanupPredicate.test(table_key, backups):
+            self.__delete_datastore_entities_for_given_table(table_key, table_reference)
 
     def __delete_backup_in_bq_and_update_datastore(self, backup):
         try:
@@ -40,10 +42,8 @@ class TableRetention(object):
                                              backup.table_id)
 
             self.big_query_service.delete_table(table_reference)
-            logging.debug("Table %s deleted from BigQuery. "
-                          "Updating datastore. Retention policy used: '%s'",
-                          table_reference,
-                          type(self.policy).__name__)
+            logging.debug("Table %s deleted from BigQuery. Updating datastore.",
+                          table_reference)
             Backup.mark_backup_deleted(backup.key)
         except TableNotFoundException:
             Backup.mark_backup_deleted(backup.key)
@@ -52,10 +52,19 @@ class TableRetention(object):
                 backup.table_id)
         except HttpError as ex:
             error_message = "Unexpected HttpError occurred while deleting " \
-                            "table '{}', error: {}: {}"\
+                            "table '{}', error: {}: {}" \
                 .format(backup.table_id, type(ex), ex)
             logging.exception(error_message)
         except Exception as ex:
-            error_message = "Could not delete backup '{}' error: {}: {}"\
+            error_message = "Could not delete backup '{}' error: {}: {}" \
                 .format(backup.table_id, type(ex), ex)
             logging.exception(error_message)
+
+    @staticmethod
+    def __delete_datastore_entities_for_given_table(url_safe_key, table_reference):
+        table_key = ndb.Key(urlsafe=url_safe_key)
+        backups_entities_to_delete = Backup.get_all_backups_sorted(table_key)
+        logging.info("Removing table and backup entites for table:'%s'", table_reference)
+        for backup in backups_entities_to_delete:
+            backup.key.delete()
+        table_key.delete()

--- a/tests/backup/datastore/test_backup.py
+++ b/tests/backup/datastore/test_backup.py
@@ -28,12 +28,12 @@ class TestBackup(unittest.TestCase):
             project_id='example-proj-name',
             dataset_id='example-dataset-name',
             table_id='example-table-name',
-            last_checked=datetime(2017, 02, 1, 16, 30)
+            last_checked=datetime(2017, 2, 1, 16, 30)
         )
         backup = Backup(
             parent=table.key,
-            last_modified=datetime(2017, 02, 1, 16, 30),
-            created=datetime(2017, 02, 1, 16, 30),
+            last_modified=datetime(2017, 2, 1, 16, 30),
+            created=datetime(2017, 2, 1, 16, 30),
             dataset_id='targetDatasetId',
             table_id='targetTableId',
             numBytes=1234
@@ -43,7 +43,7 @@ class TestBackup(unittest.TestCase):
         backup_to_check = Backup.get_by_key(backup.key)
         self.assertEqual(backup_to_check.deleted, None)
         self.assertEqual(
-            backup_to_check.created, datetime(2017, 02, 1, 16, 30))
+            backup_to_check.created, datetime(2017, 2, 1, 16, 30))
 
     def test_should_retrieve_table_using_backup(self):
         # given
@@ -51,13 +51,13 @@ class TestBackup(unittest.TestCase):
             project_id='example-proj-name',
             dataset_id='example-dataset-name',
             table_id='example-table-name',
-            last_checked=datetime(2017, 02, 1, 16, 30)
+            last_checked=datetime(2017, 2, 1, 16, 30)
         )
         table.put()
         backup = Backup(
             parent=table.key,
-            last_modified=datetime(2017, 02, 1, 16, 30),
-            created=datetime(2017, 02, 1, 16, 30),
+            last_modified=datetime(2017, 2, 1, 16, 30),
+            created=datetime(2017, 2, 1, 16, 30),
             dataset_id='targetDatasetId',
             table_id='targetTableId',
             numBytes=1234
@@ -68,7 +68,7 @@ class TestBackup(unittest.TestCase):
         table_entity = Table.get_table_from_backup(backup_entity)
         self.assertEqual(table_entity, table)
 
-    @freeze_time("2017-02-03 16:30:00")
+    @freeze_time("2017-2-3 16:30:00")
     def test_deleting_backup_is_adding_current_timestamp_in_deleted_field(
             self
         ):
@@ -77,12 +77,12 @@ class TestBackup(unittest.TestCase):
             project_id='example-proj-name',
             dataset_id='example-dataset-name',
             table_id='example-table-name',
-            last_checked=datetime(2017, 02, 1, 16, 30)
+            last_checked=datetime(2017, 2, 1, 16, 30)
         )
         backup = Backup(
             parent=table.key,
-            last_modified=datetime(2017, 02, 1, 16, 30),
-            created=datetime(2017, 02, 1, 16, 30),
+            last_modified=datetime(2017, 2, 1, 16, 30),
+            created=datetime(2017, 2, 1, 16, 30),
             dataset_id='targetDatasetId',
             table_id='targetTableId',
             numBytes=1234
@@ -92,21 +92,21 @@ class TestBackup(unittest.TestCase):
         Backup.mark_backup_deleted(backup.key)
         # then
         deleted_backup = Backup.get_by_key(backup.key)
-        self.assertEqual(deleted_backup.deleted, datetime(2017, 02, 3, 16, 30))
+        self.assertEqual(deleted_backup.deleted, datetime(2017, 2, 3, 16, 30))
 
-    def test_that_get_all_backups_sorted_will_return_only_these_with_null_deleted_column(self):# nopep8 pylint: disable=C0301, W0613
+    def test_that_get_all_not_deleted_backups_sorted_will_return_only_these_with_null_deleted_column(self):# nopep8 pylint: disable=C0301, W0613
         # given
         table = Table(
             project_id='example-proj-name',
             dataset_id='example-dataset-name',
             table_id='example-table-name',
-            last_checked=datetime(2017, 02, 1, 16, 30)
+            last_checked=datetime(2017, 2, 1, 16, 30)
         )
         table.put()
         backup1 = Backup(
             parent=table.key,
-            last_modified=datetime(2017, 02, 1, 16, 30),
-            created=datetime(2017, 02, 1, 16, 30),
+            last_modified=datetime(2017, 2, 1, 16, 30),
+            created=datetime(2017, 2, 1, 16, 30),
             dataset_id='backup_dataset',
             table_id='backup1',
             numBytes=1234,
@@ -114,19 +114,53 @@ class TestBackup(unittest.TestCase):
         backup1.put()
         backup2 = Backup(
             parent=table.key,
-            last_modified=datetime(2017, 02, 1, 16, 30),
-            created=datetime(2017, 02, 1, 16, 30),
+            last_modified=datetime(2017, 2, 1, 16, 30),
+            created=datetime(2017, 2, 1, 16, 30),
             dataset_id='backup_dataset',
             table_id='backup2',
             numBytes=1234,
-            deleted=datetime(2017, 02, 10, 16, 30)
+            deleted=datetime(2017, 2, 10, 16, 30)
         )
         backup2.put()
         # when
-        existing_backups = Backup.get_all_backups_sorted(table.key)
+        existing_backups = Backup.get_all_not_deleted_backups_sorted(table.key)
         # then
         self.assertTrue(backup1 in existing_backups)
         self.assertTrue(backup2 not in existing_backups)
+
+    def test_that_get_all_backups_sorted_will_return_also_these_with_non_null_deleted_column(self):# nopep8 pylint: disable=C0301, W0613
+        # given
+        table = Table(
+            project_id='example-proj-name',
+            dataset_id='example-dataset-name',
+            table_id='example-table-name',
+            last_checked=datetime(2017, 2, 1, 16, 30)
+        )
+        table.put()
+        backup1 = Backup(
+            parent=table.key,
+            last_modified=datetime(2017, 2, 1, 16, 30),
+            created=datetime(2017, 2, 1, 16, 30),
+            dataset_id='backup_dataset',
+            table_id='backup1',
+            numBytes=1234,
+        )
+        backup1.put()
+        backup2 = Backup(
+            parent=table.key,
+            last_modified=datetime(2017, 2, 1, 16, 30),
+            created=datetime(2017, 2, 1, 16, 30),
+            dataset_id='backup_dataset',
+            table_id='backup2',
+            numBytes=1234,
+            deleted=datetime(2017, 2, 10, 16, 30)
+        )
+        backup2.put()
+        # when
+        all_backups = Backup.get_all_backups_sorted(table.key)
+        # then
+        self.assertTrue(backup1 in all_backups)
+        self.assertTrue(backup2 in all_backups)
 
     def test_should_sort_backups_by_create_time_desc(self):
         # given
@@ -161,21 +195,21 @@ class TestBackup(unittest.TestCase):
             project_id='example-proj-name',
             dataset_id='example-dataset-name',
             table_id='example-table-name',
-            last_checked=datetime(2017, 02, 1, 16, 30)
+            last_checked=datetime(2017, 2, 1, 16, 30)
         )
         table.put()
         backup_one = Backup(
             parent=table.key,
-            last_modified=datetime(2017, 02, 1, 16, 30),
-            created=datetime(2017, 02, 1, 16, 30),
+            last_modified=datetime(2017, 2, 1, 16, 30),
+            created=datetime(2017, 2, 1, 16, 30),
             dataset_id='targetDatasetId',
             table_id='targetTableId',
             numBytes=1234
         )
         backup_two = Backup(
             parent=table.key,
-            last_modified=datetime(2018, 03, 2, 00, 00),
-            created=datetime(2018, 03, 2, 00, 00),
+            last_modified=datetime(2018, 3, 2, 00, 00),
+            created=datetime(2018, 3, 2, 00, 00),
             dataset_id='targetDatasetId',
             table_id='targetTableId',
             numBytes=1234
@@ -196,21 +230,21 @@ class TestBackup(unittest.TestCase):
             project_id='example-proj-name',
             dataset_id='example-dataset-name',
             table_id='example-table-name',
-            last_checked=datetime(2017, 02, 1, 16, 30)
+            last_checked=datetime(2017, 2, 1, 16, 30)
         )
         table.put()
         backup_one = Backup(
             parent=table.key,
-            last_modified=datetime(2017, 02, 1, 16, 30),
-            created=datetime(2017, 02, 1, 16, 30),
+            last_modified=datetime(2017, 2, 1, 16, 30),
+            created=datetime(2017, 2, 1, 16, 30),
             dataset_id='targetDatasetId',
             table_id='targetTableId',
             numBytes=1234
         )
         backup_two = Backup(
             parent=table.key,
-            last_modified=datetime(2018, 03, 2, 00, 00),
-            created=datetime(2018, 03, 2, 00, 00),
+            last_modified=datetime(2018, 3, 2, 00, 00),
+            created=datetime(2018, 3, 2, 00, 00),
             dataset_id='targetDatasetId',
             table_id='targetTableId',
             numBytes=1234

--- a/tests/commons/config/test_configuration.py
+++ b/tests/commons/config/test_configuration.py
@@ -25,6 +25,12 @@ class TestConfiguration(unittest.TestCase):
     def test_should_be_able_to_read__custom_project_list(self):
         self.__is_list_and_each_item_instance_of(self.configuration.projects_to_skip, str)
 
+    def test_should_be_able_to_read_grace_period_after_source_table_deletion_in_months(self):
+        self.__instance_of(self.configuration.grace_period_after_source_table_deletion_in_months, int)
+
+    def test_should_be_able_to_read_young_old_generation_threshold_in_months(self):
+        self.__instance_of(self.configuration.young_old_generation_threshold_in_months, int)
+
     def __instance_of(self, obj, expected_type):
         self.assertTrue(isinstance(obj, expected_type))
 

--- a/tests/retention/policy/filter/test_only_one_version_for_old_backup_filter.py
+++ b/tests/retention/policy/filter/test_only_one_version_for_old_backup_filter.py
@@ -5,18 +5,19 @@ from freezegun import freeze_time
 
 from mock import patch
 from src.backup.datastore.Backup import Backup
-from src.retention.policy.filter.only_one_version_above_7_months_filter import \
-    OnlyOneVersionAbove7MonthsFilter
+
 from src.commons.table_reference import TableReference
+from src.retention.policy.filter.only_one_version_old_backup_filter import \
+    OnlyOneVersionForOldBackupFilter
 from tests.utils.backup_utils import create_backup
 
 
-class TestOnlyOneVersionAbove7MonthsFilter(unittest.TestCase):
+class TestOnlyOneVersionForOldBackupFilter(unittest.TestCase):
     def setUp(self):
         patch('googleapiclient.discovery.build').start()
         patch('oauth2client.client.GoogleCredentials.get_application_default')\
             .start()
-        self.under_test = OnlyOneVersionAbove7MonthsFilter()
+        self.under_test = OnlyOneVersionForOldBackupFilter()
 
     def tearDown(self):
         patch.stopall()

--- a/tests/retention/test_should_perform_retention_predicate.py
+++ b/tests/retention/test_should_perform_retention_predicate.py
@@ -31,7 +31,7 @@ class TestShouldPerformRetentionPredicate(unittest.TestCase):
         # then
         self.assertEqual(True, result)
 
-    def test_should_return_false_for_empy_list(self):
+    def test_should_return_false_for_empty_list(self):
         # given
         empty_list = []
 
@@ -47,7 +47,7 @@ class TestShouldPerformRetentionPredicate(unittest.TestCase):
             self, report, _):
         # given
         backups = \
-            self.__create_backups_with_part_of_referecing_same_table_in_bq()
+            self.__create_backups_with_part_of_referencing_same_table_in_bq()
 
         # when
         result = ShouldPerformRetentionPredicate.test(backups)
@@ -66,7 +66,7 @@ class TestShouldPerformRetentionPredicate(unittest.TestCase):
         return [backup_1, backup_2, backup_3, backup_4]
 
     @staticmethod
-    def __create_backups_with_part_of_referecing_same_table_in_bq():
+    def __create_backups_with_part_of_referencing_same_table_in_bq():
         backup_1 = Backup(table_id='table_id_1', dataset_id='dataset_id_1')
         backup_2 = Backup(table_id='table_id_2', dataset_id='dataset_id_1')
         backup_3 = Backup(table_id='table_id_3', dataset_id='dataset_id_1')


### PR DESCRIPTION
…cess.

Process for removing entities about tables not existing for a long time and their backup entities.
After one month after removing last backup by retention process, the table entity and backup entities connected with them are deleted.

Hardcoded constants for managing retention are now moved to configuration.
Documentation and tests updated. Renaming filter name to not contain hardcoded value in class name.