### PR TITLE
YACHT-2298: Moving restore to another service (using backend instance…

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -33,7 +33,7 @@
 
 1. Command below deploys App Engine application:
       ```bash
-      gcloud app deploy --project ${BBQ_PROJECT_ID} app.yaml config/cron.yaml config/queue.yaml config/index.yaml
+      gcloud app deploy --project ${BBQ_PROJECT_ID} app.yaml restore-service.yaml config/cron.yaml config/queue.yaml config/index.yaml dispatch.yaml -q      
       ```
       Note: If it is your first App Engine deploy, App Engine needs to be initialised and you will need to choose [region/location](https://cloud.google.com/appengine/docs/locations). It is recommended to pick the same location as where most of your BigQuery data resides.
 1.   Secure your application by following given steps.

--- a/app.yaml
+++ b/app.yaml
@@ -2,10 +2,7 @@ runtime: python27
 api_version: 1
 threadsafe: true
 
-instance_class: B4
-basic_scaling:
-  max_instances: 25
-  idle_timeout: 10m
+instance_class: F4
 
 builtins:
 # Deferred is required to use google.appengine.ext.deferred.
@@ -28,26 +25,6 @@ skip_files:
 - src/slo
 
 handlers:
-- url: /_ah/queue/deferred
-  script: google.appengine.ext.deferred.deferred.application
-  secure: always
-  login: admin
-- url: /restore/project/.*/dataset/.*/table/.*
-  script: src.restore.table.table_restore_handler.app
-  secure: always
-- url: /restore/project/.*/dataset/.*
-  script: src.restore.dataset.dataset_restore_handler.app
-  secure: always
-- url: /restore/list
-  script: src.restore.list.backup_list_restore_handler.app
-  secure: always
-- url: /callback/restore-finished.*
-  script: src.restore.after_restore_action_handler.app
-  secure: always
-  login: admin
-- url: /restore/jobs/.*
-  script: src.restore.status.restoration_job_status_handler.app
-  secure: always
 - url: /cron/retention
   script: src.retention.retention-routing.app
   secure: always

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,0 +1,9 @@
+dispatch:
+  - url: "*/restore/*"
+    service: restore-service
+
+  - url: "*/callback/restore-finished*"
+    service: restore-service
+
+  - url: "*/_ah/queue/deferred*"
+    service: restore-service

--- a/restore-service.yaml
+++ b/restore-service.yaml
@@ -1,0 +1,51 @@
+runtime: python27
+api_version: 1
+threadsafe: true
+service: restore-service
+
+instance_class: B4
+basic_scaling:
+  max_instances: 25
+  idle_timeout: 10m
+
+builtins:
+# Deferred is required to use google.appengine.ext.deferred.
+- deferred: on
+
+libraries:
+- name: ssl
+  version: 2.7.11
+
+skip_files:
+- ^(.*/)?#.*#$
+- ^(.*/)?.*~$
+- ^(.*/)?.*\.py[co]$
+- ^(.*/)?.*/RCS/.*$
+- ^(.*/)?\..*$
+- google_appengine.*
+- gitlab-bbq
+- docs
+- tests
+- src/slo
+
+handlers:
+- url: /_ah/queue/deferred
+  script: google.appengine.ext.deferred.deferred.application
+  secure: always
+  login: admin
+- url: /restore/project/.*/dataset/.*/table/.*
+  script: src.restore.table.table_restore_handler.app
+  secure: always
+- url: /restore/project/.*/dataset/.*
+  script: src.restore.dataset.dataset_restore_handler.app
+  secure: always
+- url: /restore/list
+  script: src.restore.list.backup_list_restore_handler.app
+  secure: always
+- url: /callback/restore-finished.*
+  script: src.restore.after_restore_action_handler.app
+  secure: always
+  login: admin
+- url: /restore/jobs/.*
+  script: src.restore.status.restoration_job_status_handler.app
+  secure: always


### PR DESCRIPTION
…s as some requests take a lot of time) and migrate default service (backup/retention) to frontend instances to allow better instance scaling.