### PR TITLE
YACHT-2298: Scheduling tasks in batches (100) instead of scheduling o…

### DIFF
--- a/src/backup/dataset_backup_handler.py
+++ b/src/backup/dataset_backup_handler.py
@@ -1,9 +1,12 @@
 import logging
 
 import webapp2
+from apiclient.errors import HttpError
 
+from src.backup.task_creator import TaskCreator
 from src.commons.big_query.big_query import BigQuery
 from src.commons.config.configuration import configuration
+from src.commons.decorators.retry import retry
 from src.commons.tasks import Tasks
 
 
@@ -21,22 +24,15 @@ class DatasetBackupHandler(webapp2.RequestHandler):
     def post(self):
         project_id = self.request.get('projectId')
         dataset_id = self.request.get('datasetId')
-        logging.info('Backing up dataset: ' + dataset_id)
-        self.BQ.for_each_table(
-            project_id=project_id,
-            dataset_id=dataset_id,
-            func=self.schedule_backup_task
-        )
+        self._schedule_backup_tasks(project_id, dataset_id)
 
-    # pylint: disable=R0201
-    def schedule_backup_task(self, projectId, datasetId, tableId):
-        logging.info("Schedule_backup_task: '%s:%s.%s'",
-                     projectId, datasetId, tableId)
-        task = Tasks.create(
-            method='GET',
-            url='/tasks/backups/table/{0}/{1}/{2}'
-            .format(projectId, datasetId, tableId))
-        Tasks.schedule('backup-worker', task)
+    @retry(HttpError, tries=3, delay=2, backoff=2)
+    def _schedule_backup_tasks(self, project_id, dataset_id):
+        logging.info("Backing up dataset: '%s:%s' ", project_id, dataset_id)
+        TaskCreator.schedule_tasks_for_tables_backup(
+            project_id,
+            dataset_id,
+            self.BQ.list_table_ids(project_id, dataset_id))
 
 
 app = webapp2.WSGIApplication([

--- a/src/backup/task_creator.py
+++ b/src/backup/task_creator.py
@@ -9,7 +9,7 @@ class TaskCreator(object):
     def schedule_tasks_for_partition_backup(project_id, dataset_id,
                                             table_id, partition_ids):
         logging.info(
-            "Scheduling backup tasks for table: '%s/%s/%s partitions: %s'",
+            "Scheduling backup tasks for table: '%s:%s.%s partitions: %s'",
             project_id, dataset_id, table_id, partition_ids)
 
         tasks = []
@@ -19,4 +19,19 @@ class TaskCreator(object):
                 url='/tasks/backups/table/{}/{}/{}/{}'
                     .format(project_id, dataset_id, table_id, partition_id))
             tasks.append(task)
+        Tasks.schedule('backup-worker', tasks)
+
+    @staticmethod
+    def schedule_tasks_for_tables_backup(project_id, dataset_id, table_ids):
+        table_ids = list(table_ids)
+        logging.info(
+            "Scheduling backup tasks for dataset: '%s:%s tables: %s'",
+            project_id, dataset_id, table_ids)
+
+        tasks = []
+        for table_id in table_ids:
+            tasks.append(Tasks.create(
+                method='GET',
+                url='/tasks/backups/table/{0}/{1}/{2}'
+                    .format(project_id, dataset_id, table_id)))
         Tasks.schedule('backup-worker', tasks)

--- a/src/commons/big_query/big_query.py
+++ b/src/commons/big_query/big_query.py
@@ -68,11 +68,6 @@ class BigQuery(object):
                     yield dataset['datasetReference']['datasetId']
             request = self.service.datasets().list_next(request, datasets)
 
-    @retry(HttpError, tries=3, delay=2, backoff=2)
-    def for_each_table(self, project_id, dataset_id, func):
-        for table_id in self.list_table_ids(project_id, dataset_id):
-            func(project_id, dataset_id, table_id)
-
     def list_table_ids(self, project_id, dataset_id):
         request = self.service.tables().list(
             projectId=project_id, datasetId=dataset_id
@@ -86,7 +81,6 @@ class BigQuery(object):
                                  dataset_id)
                     return
                 raise ex
-
             if 'tables' in tables:
                 for table in tables['tables']:
                     if 'tableReference' not in table:
@@ -100,13 +94,6 @@ class BigQuery(object):
                     yield table['tableReference']['tableId']
             request = self.service.tables().list_next(request, tables)
 
-    @retry(Error, tries=3, delay=2, backoff=2)
-    def list_tables(self, project_id, dataset_id, page_token=None,
-        max_results=1000):
-        return self.service.tables().list(
-            projectId=project_id, datasetId=dataset_id,
-            maxResults=max_results, pageToken=page_token
-        ).execute()
 
     def execute_query(self, query, use_legacy_sql=True):
         query_job = self.__sync_query(query=query, use_legacy_sql=use_legacy_sql)

--- a/tests/backup/test_dataset_backup_handler.py
+++ b/tests/backup/test_dataset_backup_handler.py
@@ -1,0 +1,48 @@
+import os
+
+import mock
+from apiclient.errors import HttpError
+
+from src.backup.task_creator import TaskCreator
+from src.commons.big_query.big_query import BigQuery
+
+os.environ['SERVER_SOFTWARE'] = 'Development/'
+import unittest
+
+import webtest
+from google.appengine.ext import testbed
+from mock import patch
+
+from src.backup import dataset_backup_handler
+
+
+class TestDatasetBackupHandler(unittest.TestCase):
+    def setUp(self):
+        patch('googleapiclient.discovery.build').start()
+        self._create_http = patch.object(BigQuery, '_create_http').start()
+        app = dataset_backup_handler.app
+        self.under_test = webtest.TestApp(app)
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_memcache_stub()
+
+    def tearDown(self):
+        self.testbed.deactivate()
+        patch.stopall()
+
+    @patch('time.sleep', return_value=None)
+    @patch.object(TaskCreator, "schedule_tasks_for_tables_backup")
+    def test_that_dataset_backup_endpoint_retries_if_503(self, schedule, _):
+        # given
+        http_error_mock = HttpError(mock.Mock(status=503), 'Internal Error')
+        schedule.side_effect = [http_error_mock, None]
+
+        url = '/tasks/backups/dataset'
+        # when
+        self.under_test.post(url=url,
+                             params={"projectId": "example-proj-name",
+                                     "datasetId": "example-dataset-name"})
+
+        # then
+        self.assertEquals(2, schedule.call_count)
+

--- a/tests/backup/test_task_creator.py
+++ b/tests/backup/test_task_creator.py
@@ -4,9 +4,9 @@ import unittest
 from google.appengine.ext import testbed
 from mock import patch
 
-from src.commons.test_utils import utils
-from src.commons import request_correlation_id
 from src.backup.task_creator import TaskCreator
+from src.commons import request_correlation_id
+from src.commons.test_utils import utils
 
 
 class TestTaskCreator(unittest.TestCase):
@@ -65,3 +65,62 @@ class TestTaskCreator(unittest.TestCase):
         tasks = self.taskqueue_stub.get_filtered_tasks(
             queue_names='backup-worker')
         self.assertEqual(len(tasks), 0, "Should not create any task in queue")
+
+
+    @patch.object(request_correlation_id, 'get',
+                  return_value='correlation-id')
+    def test_should_schedule_single_table_task_if_only_one(self, _):
+        # when
+        TaskCreator.schedule_tasks_for_tables_backup("test-project",
+                                                        "test-dataset",
+                                                        ["single_table"])
+        # then
+        tasks = self.taskqueue_stub.get_filtered_tasks(
+            queue_names='backup-worker')
+        self.assertEqual(len(tasks), 1, "Should create one task in queue")
+        header_value = tasks[0].headers[
+            request_correlation_id.HEADER_NAME]
+        self.assertEqual(header_value, 'correlation-id')
+
+    @patch.object(request_correlation_id, 'get',
+                  return_value='correlation-id')
+    def test_should_schedule_two_table_task_if_two(self, _):
+        # when
+        TaskCreator.schedule_tasks_for_tables_backup("test-project",
+                                                        "test-dataset",
+                                                        ["table_1", "table_2"])
+        # then
+        tasks = self.taskqueue_stub.get_filtered_tasks(
+            queue_names='backup-worker')
+        self.assertEqual(len(tasks), 2, "Should create two task in queue")
+        header_value = tasks[0].headers[
+            request_correlation_id.HEADER_NAME]
+        self.assertEqual(header_value, 'correlation-id')
+
+    @patch.object(request_correlation_id, 'get',
+                  return_value='correlation-id')
+    def test_should_not_schedule_any_table_task_if_any_table_listed(self, _):
+        # when
+        TaskCreator.schedule_tasks_for_tables_backup("test-project",
+                                                     "test-dataset",
+                                                     [])
+        # then
+        tasks = self.taskqueue_stub.get_filtered_tasks(
+            queue_names='backup-worker')
+        self.assertEqual(len(tasks), 0, "Should not create any task in queue")
+
+    @patch.object(request_correlation_id, 'get',
+                  return_value='correlation-id')
+    def test_should_schedule_table_task_for_table_generator(self, _):
+        # when
+        TaskCreator.schedule_tasks_for_tables_backup("test-project",
+                                                     "test-dataset",
+                                                     self._table_generator())
+        # then
+        tasks = self.taskqueue_stub.get_filtered_tasks(
+            queue_names='backup-worker')
+        self.assertEqual(len(tasks), 2, "Should create 2 tasks in queue")
+
+    def _table_generator(self):
+        yield "table1"
+        yield "table2"

--- a/tests/commons/big_query/test_big_query.py
+++ b/tests/commons/big_query/test_big_query.py
@@ -78,24 +78,6 @@ class TestBigQuery(unittest.TestCase):
         # then
         self.assertEqual(context.exception.resp.status, 503)
 
-    class TestClass(object):
-        def func_for_test(self, project_id, dataset_id, table_id):
-            pass
-
-    @patch.object(BigQuery, '_create_credentials', return_value=None)
-    @patch('time.sleep', return_value=None)
-    @patch.object(TestClass, "func_for_test")
-    def test_iterating_tables_should_retry_if_gets_http_503_response_once(
-            self, func, _, _1):
-        # given
-        self._create_http.return_value = self.__create_tables_list_responses_with_503()
-
-        # when
-        BigQuery().for_each_table("project1233", "dataset_id", func)
-
-        # then
-        self.assertEquals(5, func.call_count)
-
     @patch.object(BigQuery, '_create_credentials', return_value=None)
     def test_when_dataset_not_exist_then_iterating_tables_should_not_return_any_table(
             self, _):
@@ -265,19 +247,6 @@ class TestBigQuery(unittest.TestCase):
                 'tests/json_samples/big_query/get_query_results_job_not_completed.json')),
             ({'status': '200'}, content(
                 'tests/json_samples/big_query/get_query_results_job_completed.json'))
-        ])
-
-    @staticmethod
-    def __create_tables_list_responses_with_503():
-        return HttpMockSequence([
-            ({'status': '200'},
-             content('tests/json_samples/bigquery_v2_test_schema.json')),
-            ({'status': '503'},
-             content('tests/json_samples/bigquery_503_error.json')),
-            ({'status': '200'},
-             content('tests/json_samples/bigquery_table_list_page_1.json')),
-            ({'status': '200'},
-             content('tests/json_samples/bigquery_table_list_page_last.json'))
         ])
 
     @staticmethod


### PR DESCRIPTION
…nly 1 task at a time, to increase speed of scheduling and avoid timeout.