### PR TITLE
YACHT-2298: Fix for failing partitions scheduling task when table was…

### DIFF
--- a/src/backup/scheduler/partitioned_table/partitioned_table_backup_scheduler.py
+++ b/src/backup/scheduler/partitioned_table/partitioned_table_backup_scheduler.py
@@ -1,7 +1,7 @@
 import logging
 
 from src.backup.scheduler.task_creator import TaskCreator
-from src.commons.big_query.big_query import BigQuery
+from src.commons.big_query.big_query import BigQuery, TableNotFoundException
 from src.commons.tasks import Tasks
 
 
@@ -11,10 +11,15 @@ class PartitionedTableBackupScheduler(object):
         self.big_query = BigQuery()
 
     def schedule_backup(self, project_id, dataset_id, table_id):
-        partitions = self.big_query.list_table_partitions(
+        try:
+            partitions = self.big_query.list_table_partitions(
             project_id=project_id,
             dataset_id=dataset_id,
             table_id=table_id)
+        except TableNotFoundException as ex:
+            logging.warning(ex.message)
+            return
+
         partition_ids_to_backup = [partition['partitionId'] for partition in
                                    partitions]
         if not partition_ids_to_backup:

--- a/tests/backup/on_demand/test_on_demand_table_backup.py
+++ b/tests/backup/on_demand/test_on_demand_table_backup.py
@@ -1,6 +1,7 @@
 import unittest
 
-from mock import patch
+from mock import patch, Mock
+
 from src.backup.datastore.Table import Table
 from src.backup.on_demand.on_demand_table_backup import OnDemandTableBackup
 from src.commons.big_query.big_query_table_metadata import BigQueryTableMetadata
@@ -10,6 +11,8 @@ from src.commons.table_reference import TableReference
 
 class TestOnDemandTableBackup(unittest.TestCase):
 
+    @patch('src.commons.big_query.big_query.BigQuery.__init__',
+           Mock(return_value=None))
     @patch.object(Table, "get_table", return_value=None)
     @patch('src.commons.big_query.big_query_table_metadata.BigQueryTableMetadata.get_table_by_reference',
            return_value=BigQueryTableMetadata(

--- a/tests/backup/scheduler/dataset/test_dataset_backup_scheduler.py
+++ b/tests/backup/scheduler/dataset/test_dataset_backup_scheduler.py
@@ -15,14 +15,7 @@ class TestDatasetBackupScheduler(unittest.TestCase):
     def setUp(self):
         self.testbed = testbed.Testbed()
         self.testbed.activate()
-        self.testbed.init_datastore_v3_stub()
-        self.testbed.init_memcache_stub()
-        self.testbed.init_app_identity_stub()
-        self.testbed.init_taskqueue_stub()
-        self.testbed.init_taskqueue_stub(
-            root_path=os.path.join(os.path.dirname(__file__), 'resources'))
         self.task_queue_stub = utils.init_testbed_queue_stub(self.testbed)
-        ndb.get_context().clear_cache()
 
     def tearDown(self):
         self.testbed.deactivate()

--- a/tests/backup/scheduler/dataset/test_dataset_backup_scheduler_handler.py
+++ b/tests/backup/scheduler/dataset/test_dataset_backup_scheduler_handler.py
@@ -21,7 +21,6 @@ class TestDatasetBackupSchedulerHandler(unittest.TestCase):
         self.under_test = webtest.TestApp(app)
         self.testbed = testbed.Testbed()
         self.testbed.activate()
-        self.testbed.init_memcache_stub()
 
     def tearDown(self):
         self.testbed.deactivate()

--- a/tests/backup/scheduler/organization/test_organization_backup_scheduler.py
+++ b/tests/backup/scheduler/organization/test_organization_backup_scheduler.py
@@ -16,14 +16,7 @@ class TestOrganizationBackupScheduler(unittest.TestCase):
     def setUp(self):
         self.testbed = testbed.Testbed()
         self.testbed.activate()
-        self.testbed.init_datastore_v3_stub()
-        self.testbed.init_memcache_stub()
-        self.testbed.init_app_identity_stub()
-        self.testbed.init_taskqueue_stub()
-        self.testbed.init_taskqueue_stub(
-            root_path=os.path.join(os.path.dirname(__file__), 'resources'))
         self.task_queue_stub = utils.init_testbed_queue_stub(self.testbed)
-        ndb.get_context().clear_cache()
 
     def tearDown(self):
         self.testbed.deactivate()

--- a/tests/backup/scheduler/organization/test_organization_backup_scheduler_handler.py
+++ b/tests/backup/scheduler/organization/test_organization_backup_scheduler_handler.py
@@ -22,7 +22,6 @@ class TestOrganizationBackupSchedulerHandler(unittest.TestCase):
         self.under_test = webtest.TestApp(app)
         self.testbed = testbed.Testbed()
         self.testbed.activate()
-        self.testbed.init_memcache_stub()
 
     def tearDown(self):
         self.testbed.deactivate()

--- a/tests/backup/scheduler/partitioned_table/test_partitioned_table_backup_scheduler_handler.py
+++ b/tests/backup/scheduler/partitioned_table/test_partitioned_table_backup_scheduler_handler.py
@@ -22,7 +22,6 @@ class TestPartitionedTableBackupSchedulerHandler(unittest.TestCase):
         self.under_test = webtest.TestApp(app)
         self.testbed = testbed.Testbed()
         self.testbed.activate()
-        self.testbed.init_memcache_stub()
 
     def tearDown(self):
         self.testbed.deactivate()

--- a/tests/backup/scheduler/project/test_project_backup_scheduler.py
+++ b/tests/backup/scheduler/project/test_project_backup_scheduler.py
@@ -15,14 +15,7 @@ class TestProjectBackupScheduler(unittest.TestCase):
     def setUp(self):
         self.testbed = testbed.Testbed()
         self.testbed.activate()
-        self.testbed.init_datastore_v3_stub()
-        self.testbed.init_memcache_stub()
-        self.testbed.init_app_identity_stub()
-        self.testbed.init_taskqueue_stub()
-        self.testbed.init_taskqueue_stub(
-            root_path=os.path.join(os.path.dirname(__file__), 'resources'))
         self.task_queue_stub = utils.init_testbed_queue_stub(self.testbed)
-        ndb.get_context().clear_cache()
 
     def tearDown(self):
         self.testbed.deactivate()

--- a/tests/backup/scheduler/project/test_project_backup_scheduler_handler.py
+++ b/tests/backup/scheduler/project/test_project_backup_scheduler_handler.py
@@ -21,7 +21,6 @@ class TestProjectBackupSchedulerHandler(unittest.TestCase):
         self.under_test = webtest.TestApp(app)
         self.testbed = testbed.Testbed()
         self.testbed.activate()
-        self.testbed.init_memcache_stub()
 
     def tearDown(self):
         self.testbed.deactivate()

--- a/tests/json_samples/bigquery_partition_query_404_table_not_exist.json
+++ b/tests/json_samples/bigquery_partition_query_404_table_not_exist.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "errors": [
+      {
+        "domain": "global",
+        "reason": "notFound",
+        "message": "Not found: Table proj:dataset.table was not found in location US"
+      }
+    ],
+    "code": 404,
+    "message": "Not found: Table proj:dataset.table was not found in location US"
+  }
+}


### PR DESCRIPTION
… previously removed and task fails to list partitions of non existing tables.

Added unit tests + small performance upgrades for unit tests.